### PR TITLE
feat: enable native breadcrumbs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
     - content.tabs.link
     - header.autohide
     - navigation.footer
+    - navigation.path
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top


### PR DESCRIPTION
## Summary

Enables Material for MkDocs native breadcrumb navigation using the `navigation.path` feature.

## Changes

Added `navigation.path` to theme features in `mkdocs.yml`.

## Result

Displays a breadcrumb trail above page content showing the navigation path:

```
Operator Manual > GitHub Actions > Use Cases > File Distribution > Architecture
```

Improves orientation in deeply nested documentation sections.

## Test Plan

- [x] `mkdocs build` succeeds with no warnings
- [x] Visual verification of breadcrumbs on nested pages