### PR TITLE
docs: convert paragraphs to admonitions in github-app-setup

### DIFF
--- a/docs/operator-manual/github-actions/github-app-setup/index.md
+++ b/docs/operator-manual/github-actions/github-app-setup/index.md
@@ -11,26 +11,28 @@ This guide describes the concept, setup, and configuration of a GitHub Core App 
 
 ## What is a GitHub Core App?
 
-A **GitHub Core App** is an organization-level GitHub App that provides centralized, secure authentication for GitHub Actions workflows operating across multiple repositories. It serves as the foundational authentication mechanism for org-wide automation.
+!!! abstract "Definition"
+
+    A **GitHub Core App** is an organization-level GitHub App that provides centralized, secure authentication for GitHub Actions workflows operating across multiple repositories. It serves as the foundational authentication mechanism for org-wide automation.
 
 ### Why Use a Core App?
 
-**Traditional Approach (PATs)**:
+!!! warning "Traditional Approach (PATs)"
 
-- Personal Access Tokens tied to individual user accounts
-- Token revoked when user leaves organization
-- Difficult to audit actions across repositories
-- No granular permission control
-- Lower rate limits (5000 requests/hour for authenticated users)
+    - Personal Access Tokens tied to individual user accounts
+    - Token revoked when user leaves organization
+    - Difficult to audit actions across repositories
+    - No granular permission control
+    - Lower rate limits (5000 requests/hour for authenticated users)
 
-**Core App Approach**:
+!!! tip "Core App Approach"
 
-- Organization-owned identity independent of individuals
-- Survives personnel changes
-- Complete audit trail of all actions
-- Fine-grained, repository-scoped permissions
-- Higher rate limits (5000 requests/hour per installation)
-- Team-based repository access control
+    - Organization-owned identity independent of individuals
+    - Survives personnel changes
+    - Complete audit trail of all actions
+    - Fine-grained, repository-scoped permissions
+    - Higher rate limits (5000 requests/hour per installation)
+    - Team-based repository access control
 
 ### Use Cases
 
@@ -57,19 +59,23 @@ A GitHub Core App enables:
 
 ### Required Access
 
-To create a Core App, you need:
+!!! info "Required Access"
 
-- **Organization owner** role
-- Access to organization settings: `https://github.com/organizations/{ORG}/settings/apps`
+    To create a Core App, you need:
+
+    - **Organization owner** role
+    - Access to organization settings: `https://github.com/organizations/{ORG}/settings/apps`
 
 ### Planning Considerations
 
-Before creating the app, determine:
+!!! note "Planning Considerations"
 
-1. **Permission scope** - Which repository and organization permissions are needed
-2. **Installation scope** - All repositories or specific teams
-3. **Token management** - Where secrets will be stored (repository or organization level)
-4. **Naming convention** - Standard naming (e.g., "CORE App", "Automation Core")
+    Before creating the app, determine:
+
+    1. **Permission scope** - Which repository and organization permissions are needed
+    2. **Installation scope** - All repositories or specific teams
+    3. **Token management** - Where secrets will be stored (repository or organization level)
+    4. **Naming convention** - Standard naming (e.g., "CORE App", "Automation Core")
 
 ## Guide Sections
 


### PR DESCRIPTION
## Summary

Converts key content blocks to Material for MkDocs admonitions for improved visual hierarchy and scanability.

## Changes

- **Definition** (abstract): Wraps Core App definition in abstract admonition
- **Traditional Approach** (warning): Highlights PAT drawbacks
- **Core App Approach** (tip): Highlights Core App benefits  
- **Required Access** (info): Prerequisite requirements
- **Planning Considerations** (note): Pre-setup checklist

Preserves all `###` headings for logical separation and TOC navigation.

## Test Plan

- [x] `mkdocs build` succeeds with no warnings
- [x] Visual verification of admonitions rendering