### PR TITLE
Set artifact retention to minimum (1 day)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/upload-pages-artifact@v4
         with:
           path: site/
+          retention-days: 1
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary

- Sets Pages deployment artifact retention to minimum 1 day (from default 90 days)
- Reduces storage usage for deployment artifacts that are immediately superseded

## Rationale

Since each push deploys a new site version, previous build artifacts serve no purpose after deployment. Setting minimum retention saves storage without impacting functionality.

## Test plan

- [ ] Workflow runs successfully
- [ ] Site deploys correctly
- [ ] Artifact auto-deletes after 24 hours