### PR TITLE
Add OpenTelemetry trace export to Dash0

### DIFF
--- a/.github/workflows/otel-export.yml
+++ b/.github/workflows/otel-export.yml
@@ -1,0 +1,18 @@
+name: Export OpenTelemetry Traces to Dash0
+on:
+  workflow_run:
+    workflows:
+      - "Deploy MkDocs to GitHub Pages"
+    types:
+      - completed
+jobs:
+  export-trace:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Export Workflow Trace
+        uses: corentinmusard/otel-cicd-action@v1
+        with:
+          otlpEndpoint: ${{ secrets.DASH0_OTLP_ENDPOINT }}
+          otlpHeaders: ${{ secrets.DASH0_OTLP_HEADERS }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## Summary

Adds OpenTelemetry tracing for GitHub Actions workflows, exported to Dash0.

## Changes

- `.github/workflows/otel-export.yml` - new workflow triggered after `Deploy MkDocs to GitHub Pages` completes

## How it works

1. Deploy workflow runs on push to main
2. After completion, this workflow exports trace data via OTLP
3. Traces are routed to the `github-actions` dataset in Dash0

## Secrets configured

- `DASH0_OTLP_ENDPOINT` - gRPC endpoint for Dash0 ingress
- `DASH0_OTLP_HEADERS` - Auth token and dataset routing

## View in Dash0

Filter by `service.namespace = CI-CD` or `service.namespace = adaptive-enforcement-lab/adaptive-enforcement-lab-com`