### PR TITLE
Add Giscus comments to blog posts

### DIFF
--- a/docs/blog/posts/.meta.yml
+++ b/docs/blog/posts/.meta.yml
@@ -1,0 +1,1 @@
+comments: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ extra_css:
   - stylesheets/extra.css
 theme:
   name: material
+  custom_dir: overrides
   logo: assets/ael-logo.png
   favicon: assets/ael-logo.png
   features:

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,0 +1,55 @@
+{% if page.meta.comments %}
+  <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+  <script
+    src="https://giscus.app/client.js"
+    data-repo="adaptive-enforcement-lab/adaptive-enforcement-lab-com"
+    data-repo-id="R_kgDOQcM9Vg"
+    data-category="General"
+    data-category-id="DIC_kwDOQcM9Vs4CzE__"
+    data-mapping="pathname"
+    data-strict="1"
+    data-reactions-enabled="1"
+    data-emit-metadata="0"
+    data-input-position="top"
+    data-theme="preferred_color_scheme"
+    data-lang="en"
+    data-loading="lazy"
+    crossorigin="anonymous"
+    async
+  ></script>
+
+  <script>
+    var giscus = document.querySelector("script[src*=giscus]")
+
+    // Set palette on initial load
+    var palette = __md_get("__palette")
+    if (palette && typeof palette.color === "object") {
+      var theme = palette.color.scheme === "slate"
+        ? "transparent_dark"
+        : "light"
+      giscus.setAttribute("data-theme", theme)
+    }
+
+    // Register event handlers after document loaded
+    document.addEventListener("DOMContentLoaded", function() {
+      var ref = document.querySelector("[data-md-component=palette]")
+      ref.addEventListener("change", function() {
+        var palette = __md_get("__palette")
+        if (palette && typeof palette.color === "object") {
+          var theme = palette.color.scheme === "slate"
+            ? "transparent_dark"
+            : "light"
+
+          // Instruct Giscus to change theme
+          var frame = document.querySelector(".giscus-frame")
+          if (frame) {
+            frame.contentWindow.postMessage(
+              { giscus: { setConfig: { theme } } },
+              "https://giscus.app"
+            )
+          }
+        }
+      })
+    })
+  </script>
+{% endif %}


### PR DESCRIPTION
## Summary

Adds Giscus commenting system to blog posts, powered by GitHub Discussions.

## Changes

- **mkdocs.yml**: Added `custom_dir: overrides` to theme config
- **overrides/partials/comments.html**: Giscus integration with theme sync
- **docs/blog/posts/.meta.yml**: Enables comments globally for all blog posts

## Configuration

- **Repo**: adaptive-enforcement-lab/adaptive-enforcement-lab-com
- **Category**: General discussions
- **Mapping**: pathname (each post gets its own discussion thread)
- **Theme**: Auto-syncs with site light/dark mode

## Features

- GitHub-powered comments via Discussions
- No separate account needed (uses GitHub login)
- Reactions support
- Lazy loading for performance
- Auto theme switching (light/dark)

## Prerequisites

GitHub Discussions has been enabled on this repository.