### PR TITLE
Add RSS feed generation for blog posts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - name: Install dependencies
-        run: pip install mkdocs-material pillow cairosvg
+        run: pip install mkdocs-material pillow cairosvg mkdocs-rss-plugin
       - name: Build site
         run: mkdocs build
       - name: Upload artifact

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: mkdocs-build
         name: mkdocs build
-        entry: mkdocs build --strict
+        entry: bash -c 'if [ -f .venv/bin/mkdocs ]; then .venv/bin/mkdocs build --strict; else mkdocs build --strict; fi'
         language: system
         pass_filenames: false
         files: \.(md|yml|yaml)$

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ extra:
       link: https://github.com/adaptive-enforcement-lab
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/in/markcheret/
+    - icon: material/rss
+      link: /feed_rss_created.xml
 extra_css:
   - stylesheets/extra.css
 theme:
@@ -66,6 +68,13 @@ plugins:
         - en
   - social
   - meta
+  - rss:
+      match_path: blog/posts/.*
+      date_from_meta:
+        as_creation: date
+      categories:
+        - categories
+      comments_path: "#__comments"
   - blog:
       blog_dir: blog
       post_date_format: yyyy-MM-dd


### PR DESCRIPTION
## Summary

Adds RSS feed generation for blog posts using mkdocs-rss-plugin.

## Changes

- **Deploy workflow**: Added `mkdocs-rss-plugin` to pip install
- **mkdocs.yml**: 
  - Configured RSS plugin to match `blog/posts/*` pattern
  - Added RSS icon to footer social links
- **Pre-commit**: Updated hook to prefer venv mkdocs if available

## Generated Feeds

| File | Description |
|------|-------------|
| `feed_rss_created.xml` | Posts ordered by creation date |
| `feed_rss_updated.xml` | Posts ordered by update date |
| `feed_json_created.json` | JSON feed (created) |
| `feed_json_updated.json` | JSON feed (updated) |

## Feed Content

The RSS plugin extracts content up to `<!-- more -->` marker for the feed item description, including:
- Post title, author, categories
- Publication date from frontmatter
- Link to comments section
- Social card image as enclosure

## Testing

- [x] Local build succeeds
- [x] RSS feed validates as valid XML
- [x] All 3 blog posts included in feed
- [x] Feed includes post metadata

Closes #30