### PR TITLE
Streamline blog post and fix mermaid diagrams

### DIFF
--- a/docs/blog/posts/2025-11-29-from-5-seconds-to-5-milliseconds.md
+++ b/docs/blog/posts/2025-11-29-from-5-seconds-to-5-milliseconds.md
@@ -101,7 +101,7 @@ This was a classic case for caching.
 Instead of scanning the cluster on every request, I built a cache:
 
 ```mermaid
-flowchart TD
+flowchart LR
     A[Image Push Event] --> B{Cache Hit?}
     B -->|Yes| C[Return Deployments]
     B -->|No| D[Scan Cluster]
@@ -109,10 +109,12 @@ flowchart TD
     E --> C
     C --> F[Restart Deployments]
 
+    style A fill:#65d9ef,color:#1b1d1e
     style B fill:#fd971e,color:#1b1d1e
     style C fill:#a7e22e,color:#1b1d1e
     style D fill:#f92572,color:#1b1d1e
     style E fill:#9e6ffe,color:#1b1d1e
+    style F fill:#a7e22e,color:#1b1d1e
 ```
 
 The cache is a simple hash map stored in a Kubernetes ConfigMap:
@@ -166,7 +168,7 @@ volumeMounts:
 The CLI now has a two-tier access pattern:
 
 ```mermaid
-flowchart TD
+flowchart LR
     A[Check Image] --> B{Mount Available?}
     B -->|Yes| C[Read /etc/cache]
     B -->|No| D[GET ConfigMap API]
@@ -175,9 +177,12 @@ flowchart TD
     E -->|No| D
     D --> F
 
+    style A fill:#65d9ef,color:#1b1d1e
+    style B fill:#fd971e,color:#1b1d1e
     style C fill:#a7e22e,color:#1b1d1e
     style D fill:#fd971e,color:#1b1d1e
-    style F fill:#65d9ef,color:#1b1d1e
+    style E fill:#fd971e,color:#1b1d1e
+    style F fill:#a7e22e,color:#1b1d1e
 ```
 
 !!! success "Final Results"


### PR DESCRIPTION
## Summary

- Remove architecture deep dive from blog post (moved to issue #45)
- Fix mermaid diagrams: LR layout, style all nodes with bright colors

## Changes Made

### Content
- Removed "The Architecture That Emerged" section with large system diagram
- Removed "When to Graduate from Bash to Go" section
- Added "Architecture Deep Dive" to "Coming Soon" list
- Blog post reduced from 287 to 220 lines

### Diagrams
- Changed flowcharts from TD (top-down) to LR (left-right)
- Added explicit styles to all nodes (A, E, F were unstyled/dark)
- Color scheme: cyan for start, green for success, orange for decisions

## Related

- Architecture content preserved in #45

## Test plan

- [ ] Verify `mkdocs serve` renders diagrams correctly
- [ ] Confirm LR layout displays horizontally
- [ ] Check all nodes have bright colors (no dark boxes)