### PR TITLE
docs: add external references to release pipeline guides

### DIFF
--- a/docs/blog/posts/2025-12-03-why-release-please-prs-dont-trigger-builds.md
+++ b/docs/blog/posts/2025-12-03-why-release-please-prs-dont-trigger-builds.md
@@ -26,7 +26,7 @@ This is the story of a GitHub Actions limitation that wastes hours of debugging 
 
 ## The Setup
 
-Release-please automates version management. It reads your conventional commits, generates changelogs, and creates release PRs. When those PRs merge, it tags releases.
+[Release-please](https://github.com/marketplace/actions/release-please-action) automates version management. It reads your conventional commits, generates changelogs, and creates release PRs. When those PRs merge, it tags releases.
 
 ```mermaid
 flowchart LR
@@ -64,7 +64,7 @@ When a developer pushes a branch and opens a PR through the GitHub UI, the `pull
 
 !!! warning "The GITHUB_TOKEN Limitation"
 
-    Actions triggered by `GITHUB_TOKEN` don't emit workflow events. This is a security measure to prevent recursive workflow triggers.
+    Actions triggered by `GITHUB_TOKEN` [don't emit workflow events](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). This is a security measure to prevent recursive workflow triggers.
 
 The consequence: release-please can create the most beautiful PR in the world, and your CI pipeline will completely ignore it.
 

--- a/docs/operator-manual/github-actions/use-cases/release-pipelines/release-please-setup.md
+++ b/docs/operator-manual/github-actions/use-cases/release-pipelines/release-please-setup.md
@@ -1,6 +1,6 @@
 # Release-Please Configuration
 
-Release-please automates version management based on conventional commits. It creates release PRs with updated changelogs, version bumps, and Git tags.
+[Release-please](https://github.com/marketplace/actions/release-please-action) automates version management based on conventional commits. It creates release PRs with updated changelogs, version bumps, and Git tags.
 
 ---
 
@@ -299,3 +299,11 @@ This naming is important for [workflow triggers](workflow-triggers.md).
 
 - [Change Detection](change-detection.md) - Skip unnecessary builds
 - [Workflow Triggers](workflow-triggers.md) - GITHUB_TOKEN compatibility
+
+---
+
+## References
+
+- [Release-please Action](https://github.com/marketplace/actions/release-please-action) - GitHub Marketplace
+- [Release-please repository](https://github.com/googleapis/release-please) - googleapis
+- [Conventional Commits](https://www.conventionalcommits.org/) - Specification

--- a/docs/operator-manual/github-actions/use-cases/release-pipelines/workflow-triggers.md
+++ b/docs/operator-manual/github-actions/use-cases/release-pipelines/workflow-triggers.md
@@ -6,7 +6,7 @@ Handle the GITHUB_TOKEN limitation that prevents automation tools from triggerin
 
 ## The Problem
 
-Release-please creates PRs via the GitHub API using `GITHUB_TOKEN`. These PRs don't trigger `pull_request` workflows:
+[Release-please](https://github.com/marketplace/actions/release-please-action) creates PRs via the GitHub API using `GITHUB_TOKEN`. These PRs don't trigger `pull_request` workflows:
 
 ```mermaid
 flowchart LR
@@ -30,7 +30,7 @@ flowchart LR
 
 !!! warning "GITHUB_TOKEN Security Measure"
 
-    Actions triggered by `GITHUB_TOKEN` don't emit workflow events.
+    Actions triggered by `GITHUB_TOKEN` [don't emit workflow events](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
     This prevents infinite recursion but breaks automation compatibility.
 
 ---
@@ -249,3 +249,11 @@ Test your setup:
 
 - [Protected Branches](protected-branches.md) - Handle branch protection
 - [Change Detection](change-detection.md) - Optimize builds
+
+---
+
+## References
+
+- [Release-please Action](https://github.com/marketplace/actions/release-please-action) - GitHub Marketplace
+- [GITHUB_TOKEN automatic authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) - GitHub Docs
+- [Release-please repository](https://github.com/googleapis/release-please) - googleapis


### PR DESCRIPTION
## Summary

Add missing external references to the release pipeline documentation.

## Changes

### Blog Post
- Link to [release-please action](https://github.com/marketplace/actions/release-please-action) in "The Setup" section
- Link to [GitHub GITHUB_TOKEN docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) in the warning admonition

### Operator Manual: workflow-triggers.md
- Link to release-please action in problem description
- Link to GitHub docs in warning admonition
- Add References section with all external links

### Operator Manual: release-please-setup.md
- Link to release-please action in introduction
- Add References section including Conventional Commits spec

## Test Plan

- [x] markdownlint passes
- [x] mkdocs build succeeds
- [ ] Links resolve correctly on live site