### PR TITLE
docs: correct release-please guidance to use GitHub App tokens

### DIFF
--- a/docs/blog/posts/2025-12-03-why-release-please-prs-dont-trigger-builds.md
+++ b/docs/blog/posts/2025-12-03-why-release-please-prs-dont-trigger-builds.md
@@ -14,6 +14,12 @@ slug: why-release-please-prs-dont-trigger-builds
 
 # Why Release-Please PRs Don't Trigger Your Builds
 
+!!! warning "Update: There's a Better Way"
+
+    The dual-trigger pattern described below is a **workaround**, not the real fix.
+    See [The Real Fix for Release-Please Triggers](./2025-12-04-the-real-fix-for-release-please-triggers.md)
+    for the proper solution using GitHub App tokens.
+
 The release-please PR looked perfect. Clean changelog. Proper version bump. Ready to merge.
 
 One problem: the build pipeline never ran. Branch protection blocked the merge. No required checks had passed, because no checks had started.

--- a/docs/blog/posts/2025-12-04-the-real-fix-for-release-please-triggers.md
+++ b/docs/blog/posts/2025-12-04-the-real-fix-for-release-please-triggers.md
@@ -1,0 +1,174 @@
+---
+date: 2025-12-04
+authors:
+  - mark
+categories:
+  - CI/CD
+  - GitHub Actions
+  - Engineering Patterns
+description: >-
+  The dual-trigger pattern was a workaround. GitHub App tokens are the
+  real fix for release-please workflow triggers.
+slug: the-real-fix-for-release-please-triggers
+---
+
+# The Real Fix for Release-Please Triggers
+
+Yesterday I wrote about [why release-please PRs don't trigger builds](./2025-11-27-idempotent-automation.md) and proposed a dual-trigger pattern as the fix. Today I discovered that pattern is a workaround with side effects. Here's the actual solution.
+
+<!-- more -->
+
+---
+
+## The Workaround I Documented
+
+The [previous post](./2025-12-03-why-release-please-prs-dont-trigger-builds.md) explained that `GITHUB_TOKEN` actions don't emit workflow events, and proposed adding a secondary `push` trigger:
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches:
+      - 'release-please--**'
+```
+
+This works. Release-please commits trigger `push` events, so the build runs.
+
+But it's solving the wrong problem.
+
+---
+
+## The Actual Problem
+
+The issue isn't that we need a different trigger. The issue is that `GITHUB_TOKEN` is the wrong authentication mechanism for release-please.
+
+GitHub Apps are treated as separate actors. When a GitHub App creates a PR, the `pull_request` event fires normally. No workarounds needed.
+
+```mermaid
+flowchart LR
+    subgraph token[GITHUB_TOKEN]
+        T1[Create PR] --> T2[No event]
+    end
+
+    subgraph app[GitHub App]
+        A1[Create PR] --> A2[pull_request event]
+    end
+
+    T2 -.->|workaround needed| Build
+    A2 --> Build[Build Pipeline]
+
+    style T1 fill:#f92572,color:#1b1d1e
+    style T2 fill:#f92572,color:#1b1d1e
+    style A1 fill:#a7e22e,color:#1b1d1e
+    style A2 fill:#a7e22e,color:#1b1d1e
+    style Build fill:#65d9ef,color:#1b1d1e
+```
+
+---
+
+## The Real Fix
+
+Generate a GitHub App token and pass it to release-please:
+
+```yaml
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CORE_APP_ID }}
+          private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
+          owner: your-org
+
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+```
+
+That's it. The PR now triggers `pull_request` events like any developer-created PR.
+
+---
+
+## Why Not a PAT?
+
+Personal Access Tokens also work, but they're the wrong tool:
+
+- Tied to individual user accounts
+- Revoked when the user leaves
+- Broader permissions than needed
+- Manual rotation required
+
+GitHub Apps are [the proper solution](../../operator-manual/github-actions/github-app-setup/index.md) for machine-to-machine authentication.
+
+---
+
+## The Duplicate Trigger Problem
+
+If you implemented my original workaround and then add the GitHub App fix, you'll get duplicate workflow runs:
+
+1. `pull_request` event fires (GitHub App works correctly)
+2. `push` event fires (workaround still active)
+
+The fix: remove the workaround.
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  # push trigger for release-please branches - REMOVED
+  # No longer needed with GitHub App token
+  workflow_dispatch:
+```
+
+---
+
+## Before and After
+
+| Aspect | Dual-Trigger Workaround | GitHub App Token |
+|--------|------------------------|------------------|
+| Event type | `push` | `pull_request` |
+| PR context available | Limited | Full |
+| Duplicate runs risk | Yes, if both triggers exist | No |
+| Setup complexity | Low | Medium (one-time App setup) |
+| Authentication model | Default token | Proper machine identity |
+
+---
+
+## When to Use the Workaround
+
+The dual-trigger pattern still has a place:
+
+- **No GitHub App available** - Teams without org-level App access
+- **Quick testing** - Validating the concept before proper setup
+- **Simple repos** - Where the complexity isn't justified
+
+But for production pipelines, use the GitHub App approach.
+
+---
+
+## Updated Documentation
+
+The [Release Pipelines guide](../../operator-manual/github-actions/use-cases/release-pipelines/index.md) has been updated to reflect this. The dual-trigger pattern is now documented as a fallback, not the primary solution.
+
+---
+
+## Lessons Learned
+
+1. **Workarounds become technical debt** - The dual-trigger pattern solved the symptom, not the cause
+2. **Question the constraint** - Instead of "how do I trigger on push?", ask "why isn't pull_request working?"
+3. **GitHub Apps are underutilized** - They solve many authentication edge cases cleanly
+
+---
+
+*The build pipeline now runs on `pull_request` events. No workarounds. No duplicate runs. Just proper authentication.*

--- a/docs/operator-manual/github-actions/use-cases/release-pipelines/release-please-setup.md
+++ b/docs/operator-manual/github-actions/use-cases/release-pipelines/release-please-setup.md
@@ -175,7 +175,9 @@ Control how commits appear in changelogs:
 
 ## Workflow Integration
 
-### Basic Workflow
+### Recommended: GitHub App Token
+
+Use a GitHub App token to ensure release-please PRs trigger build pipelines correctly. See [Workflow Triggers](workflow-triggers.md) for why this matters.
 
 ```yaml
 name: Release Please
@@ -195,13 +197,30 @@ jobs:
       backend_release: ${{ steps.release.outputs['packages/backend--release_created'] }}
       frontend_release: ${{ steps.release.outputs['packages/frontend--release_created'] }}
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CORE_APP_ID }}
+          private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
+          owner: your-org
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 ```
+
+For GitHub App setup, see [GitHub App Setup](../../github-app-setup/index.md).
+
+!!! warning "Why Not GITHUB_TOKEN?"
+
+    Using the default `GITHUB_TOKEN` prevents release-please PRs from
+    triggering build pipelines. This is a [GitHub security measure](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)
+    to prevent infinite loops. GitHub Apps are treated as separate actors
+    and don't have this limitation.
 
 ### Output Reference
 

--- a/docs/operator-manual/github-actions/use-cases/release-pipelines/workflow-triggers.md
+++ b/docs/operator-manual/github-actions/use-cases/release-pipelines/workflow-triggers.md
@@ -1,31 +1,31 @@
 # Workflow Triggers
 
-Handle the GITHUB_TOKEN limitation that prevents automation tools from triggering workflows.
+Ensure release-please PRs trigger your build pipelines correctly.
 
 ---
 
 ## The Problem
 
-[Release-please](https://github.com/marketplace/actions/release-please-action) creates PRs via the GitHub API using `GITHUB_TOKEN`. These PRs don't trigger `pull_request` workflows:
+[Release-please](https://github.com/marketplace/actions/release-please-action) creates PRs via the GitHub API. When using the default `GITHUB_TOKEN`, these PRs don't trigger `pull_request` workflows:
 
 ```mermaid
 flowchart LR
-    subgraph developer[Developer Flow]
-        D1[git push] --> D2[pull_request event]
+    subgraph token[Using GITHUB_TOKEN]
+        T1[Create PR] --> T2[No event]
     end
 
-    subgraph automation[Automation Flow]
-        A1[API Create PR] --> A2[No event]
+    subgraph app[Using GitHub App]
+        A1[Create PR] --> A2[pull_request event]
     end
 
-    D2 --> Build[Build Pipeline]
-    A2 -.->|blocked| Build
+    T2 -.->|blocked| Build[Build Pipeline]
+    A2 --> Build
 
-    style D1 fill:#65d9ef,color:#1b1d1e
-    style D2 fill:#a7e22e,color:#1b1d1e
-    style A1 fill:#9e6ffe,color:#1b1d1e
-    style A2 fill:#f92572,color:#1b1d1e
-    style Build fill:#a7e22e,color:#1b1d1e
+    style T1 fill:#f92572,color:#1b1d1e
+    style T2 fill:#f92572,color:#1b1d1e
+    style A1 fill:#a7e22e,color:#1b1d1e
+    style A2 fill:#a7e22e,color:#1b1d1e
+    style Build fill:#65d9ef,color:#1b1d1e
 ```
 
 !!! warning "GITHUB_TOKEN Security Measure"
@@ -35,21 +35,83 @@ flowchart LR
 
 ---
 
-## Event Behavior
+## The Solution: GitHub App Token
 
-| Action | Git Push | API (GITHUB_TOKEN) |
-|--------|----------|-------------------|
-| Push to branch | `push` event | `push` event |
-| Create PR | `pull_request` event | **No event** |
-| Update PR | `pull_request` event | **No event** |
+GitHub Apps are treated as separate actors. When a GitHub App creates a PR, the `pull_request` event fires normally.
 
-The key insight: even with `GITHUB_TOKEN`, pushing commits to a branch emits `push` events. Only PR operations are silent.
+```yaml
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CORE_APP_ID }}
+          private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
+          owner: your-org
+
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+```
+
+!!! success "Result"
+
+    Release-please PRs now trigger `pull_request` events like any developer-created PR.
+    No workarounds needed.
+
+For GitHub App setup instructions, see [GitHub App Setup](../../github-app-setup/index.md).
 
 ---
 
-## The Dual-Trigger Solution
+## Build Pipeline Configuration
 
-Add a secondary `push` trigger for automation branches:
+With the GitHub App token, your build pipeline needs only standard triggers:
+
+```yaml
+name: Build Pipeline
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+```
+
+No special handling for release-please branches required.
+
+---
+
+## Why Not a PAT?
+
+Personal Access Tokens also trigger workflow events, but they're the wrong tool:
+
+| Aspect | PAT | GitHub App |
+|--------|-----|------------|
+| Identity | Tied to user account | Machine identity |
+| Lifecycle | Revoked when user leaves | Survives personnel changes |
+| Permissions | Broad, user-level | Fine-grained, scoped |
+| Rotation | Manual | Automatic (tokens expire, keys rotatable) |
+| Audit | Actions attributed to user | Actions attributed to App |
+
+GitHub Apps are [the proper solution](../../github-app-setup/index.md#why_use_a_core_app) for machine-to-machine authentication.
+
+---
+
+## Fallback: Dual-Trigger Pattern
+
+If you don't have access to a GitHub App, you can use a workaround that exploits push events:
 
 ```yaml
 on:
@@ -61,33 +123,23 @@ on:
       - 'release-please--**'
 ```
 
-```mermaid
-flowchart TD
-    subgraph sources[Event Sources]
-        Dev[Developer Push] --> PR[pull_request event]
-        RP[Release-Please Commit] --> Push[push event]
-    end
+!!! warning "Workaround Limitations"
 
-    subgraph triggers[Workflow Triggers]
-        PR --> Match1{Branch: main?}
-        Push --> Match2{Branch: release-please--**?}
-    end
+    - Uses `push` events instead of `pull_request` (limited PR context)
+    - Risk of duplicate runs if you later add GitHub App token
+    - Different event type than regular PRs
 
-    Match1 -->|yes| Build[Build Pipeline]
-    Match2 -->|yes| Build
+### How It Works
 
-    style Dev fill:#65d9ef,color:#1b1d1e
-    style RP fill:#9e6ffe,color:#1b1d1e
-    style PR fill:#fd971e,color:#1b1d1e
-    style Push fill:#fd971e,color:#1b1d1e
-    style Match1 fill:#fd971e,color:#1b1d1e
-    style Match2 fill:#fd971e,color:#1b1d1e
-    style Build fill:#a7e22e,color:#1b1d1e
-```
+Even with `GITHUB_TOKEN`, pushing commits to a branch emits `push` events. Only PR operations are silent:
 
----
+| Action | Git Push | API (GITHUB_TOKEN) |
+|--------|----------|-------------------|
+| Push to branch | `push` event | `push` event |
+| Create PR | `pull_request` event | **No event** |
+| Update PR | `pull_request` event | **No event** |
 
-## Branch Patterns
+### Branch Patterns
 
 Release-please uses specific branch naming:
 
@@ -98,90 +150,54 @@ Release-please uses specific branch naming:
 
 The glob `release-please--**` matches both patterns.
 
-!!! tip "Verify Your Pattern"
-
-    Check what branches release-please actually creates in your repository.
-    Branch naming conventions may differ between versions.
-
 ---
 
-## Alternative Approaches
+## Migrating from Dual-Trigger to GitHub App
 
-### Personal Access Token
+If you implemented the dual-trigger workaround and now want to use a GitHub App:
 
-Use a PAT instead of `GITHUB_TOKEN`:
+1. **Add the GitHub App token** to your release workflow
+2. **Remove the push trigger** from your build workflow
+3. **Test** by merging a conventional commit
 
-```yaml
-- uses: googleapis/release-please-action@v4
-  with:
-    token: ${{ secrets.RELEASE_PLEASE_PAT }}
-```
+!!! danger "Remove the Workaround"
 
-Drawbacks:
+    If you keep both the dual-trigger and GitHub App token, you'll get
+    duplicate workflow runs (one from `push`, one from `pull_request`).
 
-- Requires PAT management and rotation
-- Broader permissions than necessary
-- Different auth mechanism for one workflow
-
-### GitHub App Token
-
-Use a GitHub App for authentication:
-
-```yaml
-- uses: actions/create-github-app-token@v1
-  id: app-token
-  with:
-    app-id: ${{ secrets.APP_ID }}
-    private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-- uses: googleapis/release-please-action@v4
-  with:
-    token: ${{ steps.app-token.outputs.token }}
-```
-
-Better security but more complex setup. See [GitHub App Setup](../../github-app-setup/index.md).
-
-### pull_request_target
-
-For workflows that need PR context from forks:
+Before:
 
 ```yaml
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
+  push:
+    branches:
+      - 'release-please--**'  # Remove this
 ```
 
-!!! danger "Security Risk"
-
-    `pull_request_target` runs with write permissions in the context of
-    the base branch. Use with extreme caution for untrusted contributions.
-
----
-
-## Recommended Pattern
-
-The dual-trigger approach is simplest for release-please:
+After:
 
 ```yaml
-name: Build Pipeline
 on:
-  # Regular PRs from developers
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
-
-  # Release-please PRs (commits trigger push events)
-  push:
-    branches:
-      - 'release-please--**'
-
-  # Manual trigger
-  workflow_dispatch:
-
-concurrency:
-  group: build-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # push trigger removed - GitHub App token handles this
 ```
+
+---
+
+## Other Automation Tools
+
+The same principle applies to other tools:
+
+| Tool | Recommended | Fallback |
+|------|-------------|----------|
+| Release-please | GitHub App token | `push` trigger for `release-please--**` |
+| Renovate (self-hosted) | GitHub App token | `push` trigger for `renovate/**` |
+| Custom bots | GitHub App token | Tool-specific branch patterns |
+| Dependabot | Built-in (uses `pull_request_target`) | N/A |
 
 ---
 
@@ -210,27 +226,14 @@ concurrency:
 
 ---
 
-## Other Automation Tools
-
-The same pattern applies to other tools that use `GITHUB_TOKEN`:
-
-| Tool | Branch Pattern |
-|------|---------------|
-| Release-please | `release-please--**` |
-| Renovate (self-hosted) | `renovate/**` |
-| Custom bots | Varies |
-
-Dependabot is different - it uses `pull_request_target` by default.
-
----
-
 ## Troubleshooting
 
 | Issue | Cause | Solution |
 |-------|-------|----------|
-| No build on release PR | GITHUB_TOKEN limitation | Add push trigger for release-please branches |
-| Duplicate builds | Both triggers match | Check concurrency groups |
+| No build on release PR | Using `GITHUB_TOKEN` | Use GitHub App token for release-please |
+| Duplicate builds | Both App token and push trigger | Remove the push trigger workaround |
 | Wrong ref in build | Using `github.ref` on PR | Use `github.head_ref` for PR builds |
+| App token not working | Missing permissions | Verify App has `contents: write` and `pull-requests: write` |
 
 ---
 
@@ -240,13 +243,14 @@ Test your setup:
 
 1. Merge a conventional commit (`feat: new feature`)
 2. Verify release-please creates a PR
-3. Verify build pipeline runs on the PR
-4. Check workflow run shows the correct trigger
+3. Verify build pipeline runs with `pull_request` event (not `push`)
+4. Check workflow run shows correct trigger type
 
 ---
 
 ## Next Steps
 
+- [GitHub App Setup](../../github-app-setup/index.md) - Configure the GitHub App
 - [Protected Branches](protected-branches.md) - Handle branch protection
 - [Change Detection](change-detection.md) - Optimize builds
 
@@ -256,4 +260,5 @@ Test your setup:
 
 - [Release-please Action](https://github.com/marketplace/actions/release-please-action) - GitHub Marketplace
 - [GITHUB_TOKEN automatic authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) - GitHub Docs
+- [create-github-app-token Action](https://github.com/actions/create-github-app-token) - GitHub
 - [Release-please repository](https://github.com/googleapis/release-please) - googleapis


### PR DESCRIPTION
## Summary

- Corrects the release pipeline documentation to present GitHub App tokens as the primary solution
- The dual-trigger pattern (previously documented as the fix) is actually a workaround with side effects
- GitHub Apps are separate actors, so their actions trigger workflow events normally

## Changes

- **New blog post**: Follow-up post explaining the real fix and why the dual-trigger pattern is a workaround
- **Update notice**: Original blog post now links to the correction
- **workflow-triggers.md**: Overhauled with App token as primary solution, dual-trigger as fallback
- **release-please-setup.md**: Updated with App token configuration and warning about GITHUB_TOKEN
- **index.md**: Updated overview with correct architecture diagrams and prerequisites

## Why This Matters

If users implement both the dual-trigger workaround AND the GitHub App fix, they get duplicate workflow runs. The documentation now guides users to the proper solution first.

## Test plan

- [x] Markdownlint passes
- [x] mkdocs build succeeds
- [ ] Review mermaid diagrams render correctly
- [ ] Verify cross-references link properly