### PR TITLE
docs: add graceful degradation pattern

### DIFF
--- a/docs/blog/posts/2025-11-29-from-5-seconds-to-5-milliseconds.md
+++ b/docs/blog/posts/2025-11-29-from-5-seconds-to-5-milliseconds.md
@@ -202,7 +202,7 @@ flowchart LR
     1. **Cache aggressively**: If the answer changes rarely, don't recompute it
     2. **Use Kubernetes primitives**: ConfigMaps are free, Redis is not
     3. **Mount over API**: Volume mounts eliminate network round-trips
-    4. **Graceful degradation**: Always have a fallback (mount → API → rebuild)
+    4. **[Graceful degradation](../../developer-guide/engineering-practices/patterns/graceful-degradation/index.md)**: Always have a fallback (mount → API → rebuild)
     5. **Measure first**: I didn't know the cluster scan was slow until I measured
 
 ---

--- a/docs/blog/posts/2025-12-05-the-art-of-failing-gracefully.md
+++ b/docs/blog/posts/2025-12-05-the-art-of-failing-gracefully.md
@@ -1,0 +1,186 @@
+---
+date: 2025-12-05
+authors:
+  - mark
+categories:
+  - Engineering Patterns
+  - DevSecOps
+  - Reliability
+slug: the-art-of-failing-gracefully
+description: >-
+  When your fast path fails, don't crash. Build tiered fallbacks that degrade performance, not availability.
+---
+
+# The Art of Failing Gracefully: Tiered Fallbacks for CI/CD
+
+My workflow reads deployment mappings from a ConfigMap mounted as a volume. Five milliseconds, zero API calls. But what happens when the mount fails?
+
+The answer isn't "return an error." It's "try the next thing."
+
+<!-- more -->
+
+---
+
+## The Three-Tier Pattern
+
+Every robust system I've built follows the same structure:
+
+```mermaid
+flowchart TD
+    subgraph request[Request]
+        A[Operation Requested]
+    end
+
+    subgraph tiers[Fallback Tiers]
+        T1[Tier 1: Optimal]
+        T2[Tier 2: Acceptable]
+        T3[Tier 3: Guaranteed]
+    end
+
+    subgraph result[Result]
+        Success[Success]
+    end
+
+    A --> T1
+    T1 -->|Works| Success
+    T1 -->|Fails| T2
+    T2 -->|Works| Success
+    T2 -->|Fails| T3
+    T3 --> Success
+
+    style A fill:#65d9ef,color:#1b1d1e
+    style T1 fill:#a7e22e,color:#1b1d1e
+    style T2 fill:#fd971e,color:#1b1d1e
+    style T3 fill:#f92572,color:#1b1d1e
+    style Success fill:#a7e22e,color:#1b1d1e
+```
+
+- **Tier 1**: Fast, cheap, preferred
+- **Tier 2**: Slower, costlier, reliable
+- **Tier 3**: Expensive but always works
+
+The key insight: **degrade performance, not availability**.
+
+---
+
+## Real Numbers
+
+In [From 5 Seconds to 5 Milliseconds](2025-11-29-from-5-seconds-to-5-milliseconds.md), I documented how a ConfigMap cache transformed deployment automation. But the story doesn't end at "use a cache." The real pattern is the fallback chain:
+
+| Tier | Method | Latency | API Calls |
+|------|--------|---------|-----------|
+| 1 | Volume mount | 1-5ms | 0 |
+| 2 | API call | 50-200ms | 1 |
+| 3 | Cluster scan | 5-10s | 100+ |
+
+When Tier 1 works (99% of the time), the system flies. When it doesn't, the system still works. That's the difference between a cache optimization and a reliability pattern.
+
+---
+
+## The Code Pattern
+
+```go
+func GetDeployments(image string) ([]Deployment, error) {
+    // Tier 1: Try volume mount
+    if data, err := os.ReadFile("/etc/cache/deployments.json"); err == nil {
+        metrics.RecordTier("mount")
+        return parseDeployments(data, image)
+    }
+
+    // Tier 2: Try API call
+    if data, err := k8s.GetConfigMap("deployment-cache"); err == nil {
+        metrics.RecordTier("api")
+        return parseDeployments(data, image)
+    }
+
+    // Tier 3: Rebuild from cluster scan
+    metrics.RecordTier("rebuild")
+    return scanClusterForImage(image)
+}
+```
+
+Notice the `metrics.RecordTier()` calls. You need to know which tier is serving traffic. If Tier 1 starts failing, you want to know before your users notice the latency spike.
+
+---
+
+## Fail Fast vs Degrade Gracefully
+
+These patterns aren't opposites. They solve different problems:
+
+| Scenario | Pattern | Why |
+|----------|---------|-----|
+| Invalid input | Fail Fast | User error, report immediately |
+| Missing config | Fail Fast | Can't continue safely |
+| Cache miss | Graceful Degradation | Expensive path still works |
+| Network timeout | Graceful Degradation | Infrastructure issue, retry |
+
+**Decision rule**: Fail fast on **precondition failures**. Degrade gracefully on **runtime failures**.
+
+Preconditions are things that *should* be true before you start. Runtime failures are things that *might* go wrong during execution.
+
+---
+
+## The Anti-Patterns
+
+I've seen these kill systems:
+
+### Silent Degradation
+
+```go
+// Dangerous: no observability
+if data, _ := cache.Get(); data != nil {
+    return data
+}
+return fetchFromAPI()  // Who knows we're degraded?
+```
+
+If Tier 1 silently fails for a week, you'll only notice when someone asks why the system is slow. By then, you've been burning API quota and adding latency for thousands of requests.
+
+### No Guaranteed Tier
+
+```go
+// Dangerous: can fail completely
+if cfg := cache.Get(); cfg != nil {
+    return cfg
+}
+return api.FetchConfig()  // What if API is also down?
+```
+
+Every chain needs a final tier that **cannot fail**. A static default. A hardcoded fallback. Something that always returns a valid response, even if it's stale or incomplete.
+
+### Expensive Default
+
+```yaml
+# Wasteful: always does the expensive thing
+- run: npm ci
+- uses: actions/cache/save@v4
+```
+
+If you're always running Tier 3 and then caching the result, you've inverted the pattern. The point is to *avoid* the expensive path, not run it every time.
+
+---
+
+## Implementation Checklist
+
+Before shipping graceful degradation:
+
+1. **Define all tiers** before writing code
+2. **Identify the guaranteed tier** that always succeeds
+3. **Instrument each tier** with metrics and logs
+4. **Alert on tier shifts** (Tier 1 failure rate > 5%)
+5. **Test fallback paths in CI**, not just production
+6. **Document expected latencies** per tier
+7. **Set SLOs per tier** (Tier 1: p99 < 10ms)
+
+---
+
+## Further Reading
+
+The full pattern documentation is in the Developer Guide:
+
+- [Graceful Degradation Pattern](../../developer-guide/engineering-practices/patterns/graceful-degradation/index.md) - Complete implementation guide
+- [Cache Considerations](../../developer-guide/engineering-practices/patterns/idempotency/caches.md) - Cache-resilient strategies
+
+---
+
+*The best systems don't avoid failure. They survive it.*

--- a/docs/developer-guide/engineering-practices/patterns/graceful-degradation/index.md
+++ b/docs/developer-guide/engineering-practices/patterns/graceful-degradation/index.md
@@ -1,0 +1,286 @@
+# Graceful Degradation
+
+When the optimal path fails, fall back to progressively more expensive but reliable alternatives.
+
+---
+
+## Overview
+
+Graceful degradation is a design principle that ensures systems continue operating when components fail. Rather than crashing or returning errors, the system automatically falls back to slower but working alternatives.
+
+```mermaid
+flowchart TD
+    subgraph request[Request]
+        A[Operation Requested]
+    end
+
+    subgraph tiers[Fallback Tiers]
+        T1[Tier 1: Optimal]
+        T2[Tier 2: Acceptable]
+        T3[Tier 3: Guaranteed]
+    end
+
+    subgraph result[Result]
+        Success[Success]
+    end
+
+    A --> T1
+    T1 -->|Works| Success
+    T1 -->|Fails| T2
+    T2 -->|Works| Success
+    T2 -->|Fails| T3
+    T3 --> Success
+
+    style A fill:#65d9ef,color:#1b1d1e
+    style T1 fill:#a7e22e,color:#1b1d1e
+    style T2 fill:#fd971e,color:#1b1d1e
+    style T3 fill:#f92572,color:#1b1d1e
+    style Success fill:#a7e22e,color:#1b1d1e
+```
+
+The key insight: **degrade performance, not availability**.
+
+---
+
+## The Tiered Fallback Pattern
+
+Every graceful degradation implementation follows this structure:
+
+| Tier | Characteristics | Example |
+|------|-----------------|---------|
+| **Tier 1: Optimal** | Fast, cheap, preferred | Volume mount read |
+| **Tier 2: Acceptable** | Slower, costlier, reliable | API call |
+| **Tier 3: Guaranteed** | Expensive but always works | Full rebuild |
+
+Each tier must:
+
+1. **Detect failure** of the previous tier
+2. **Attempt its operation** independently
+3. **Report which tier succeeded** (observability)
+
+---
+
+## Real-World Examples
+
+### Cache Access Pattern
+
+From [From 5 Seconds to 5 Milliseconds](../../../../blog/posts/2025-11-29-from-5-seconds-to-5-milliseconds.md):
+
+```text
+Volume Mount → API Call → Rebuild Cache
+    1-5ms        50ms        5000ms
+```
+
+```yaml
+# Kubernetes volume mount with optional flag
+volumes:
+  - name: cache-volume
+    configMap:
+      name: deployment-cache
+      optional: true  # Tier 1 can fail gracefully
+```
+
+```go
+func GetDeployments(image string) ([]Deployment, error) {
+    // Tier 1: Try volume mount
+    if data, err := os.ReadFile("/etc/cache/deployments.json"); err == nil {
+        return parseDeployments(data, image)
+    }
+
+    // Tier 2: Try API call
+    if data, err := k8s.GetConfigMap("deployment-cache"); err == nil {
+        return parseDeployments(data, image)
+    }
+
+    // Tier 3: Rebuild from cluster scan
+    return scanClusterForImage(image)
+}
+```
+
+### CI/CD Dependency Resolution
+
+```text
+Artifact Cache → Dependency Cache → Fresh Install
+    seconds          minutes          minutes+
+```
+
+```yaml
+- uses: actions/cache@v4
+  id: artifact-cache
+  with:
+    path: dist/
+    key: build-${{ hashFiles('src/**') }}
+
+- uses: actions/cache@v4
+  if: steps.artifact-cache.outputs.cache-hit != 'true'
+  id: dep-cache
+  with:
+    path: node_modules/
+    key: deps-${{ hashFiles('package-lock.json') }}
+
+- name: Install dependencies
+  if: steps.dep-cache.outputs.cache-hit != 'true'
+  run: npm ci
+
+- name: Build
+  if: steps.artifact-cache.outputs.cache-hit != 'true'
+  run: npm run build
+```
+
+### API Resilience
+
+```text
+Primary Endpoint → Secondary Endpoint → Cached Response → Static Fallback
+```
+
+### Authentication
+
+```text
+SSO → API Token → Service Account → Anonymous (read-only)
+```
+
+---
+
+## Graceful Degradation vs Fail Fast
+
+These patterns are **complementary**, not contradictory:
+
+| Scenario | Pattern | Reasoning |
+|----------|---------|-----------|
+| **Precondition not met** | Fail Fast | Don't waste resources on doomed operations |
+| **Runtime component fails** | Graceful Degradation | Continue with fallback |
+| **Invalid input** | Fail Fast | User error, report immediately |
+| **Network timeout** | Graceful Degradation | Infrastructure issue, retry/fallback |
+| **Missing required config** | Fail Fast | Can't continue safely |
+| **Cache miss** | Graceful Degradation | Expensive path still works |
+
+**Decision rule**: Fail fast on **precondition failures**. Degrade gracefully on **runtime failures**.
+
+---
+
+## Anti-Patterns
+
+### 1. Silent Degradation
+
+Degrading without logging or alerting means you won't know when Tier 1 is broken.
+
+```go
+// Bad: silent fallback
+func getData() []byte {
+    if data, _ := cache.Get(); data != nil {
+        return data
+    }
+    return fetchFromAPI()  // No indication we're in degraded mode
+}
+
+// Good: observable fallback
+func getData() []byte {
+    if data, err := cache.Get(); err == nil {
+        metrics.CacheHit()
+        return data
+    }
+    metrics.CacheMiss()
+    log.Warn("cache miss, falling back to API")
+    return fetchFromAPI()
+}
+```
+
+### 2. No Guaranteed Tier
+
+Every chain needs a final tier that **always succeeds**.
+
+```go
+// Bad: can fail completely
+func getConfig() (*Config, error) {
+    if cfg := cache.Get(); cfg != nil {
+        return cfg, nil
+    }
+    return api.FetchConfig()  // What if API is also down?
+}
+
+// Good: guaranteed fallback
+func getConfig() *Config {
+    if cfg := cache.Get(); cfg != nil {
+        return cfg
+    }
+    if cfg, err := api.FetchConfig(); err == nil {
+        return cfg
+    }
+    return DefaultConfig()  // Always works
+}
+```
+
+### 3. Expensive Default Path
+
+Using Tier 3 as the happy path defeats the purpose.
+
+```yaml
+# Bad: always does full install
+- run: npm ci
+- uses: actions/cache/save@v4
+  with:
+    path: node_modules/
+
+# Good: cache-first approach
+- uses: actions/cache@v4
+  id: cache
+  with:
+    path: node_modules/
+    key: deps-${{ hashFiles('package-lock.json') }}
+
+- if: steps.cache.outputs.cache-hit != 'true'
+  run: npm ci
+```
+
+### 4. No Observability
+
+You need to know:
+
+- Which tier is serving traffic
+- How often fallbacks occur
+- Latency per tier
+
+```yaml
+- name: Report cache tier
+  run: |
+    if [ "${{ steps.mount-cache.outcome }}" = "success" ]; then
+      echo "cache_tier=mount" >> metrics.txt
+    elif [ "${{ steps.api-cache.outcome }}" = "success" ]; then
+      echo "cache_tier=api" >> metrics.txt
+    else
+      echo "cache_tier=rebuild" >> metrics.txt
+    fi
+```
+
+---
+
+## Implementation Checklist
+
+Before implementing graceful degradation:
+
+- [ ] **Define all tiers** before writing code
+- [ ] **Identify the guaranteed tier** that always succeeds
+- [ ] **Instrument each tier** with metrics/logs
+- [ ] **Alert on tier shifts** (e.g., Tier 1 failure rate > 5%)
+- [ ] **Test fallback paths** in CI, not just production
+- [ ] **Document expected latencies** for each tier
+- [ ] **Set SLOs per tier** (Tier 1: p99 < 10ms, Tier 2: p99 < 500ms)
+
+---
+
+## Relationship to Other Patterns
+
+| Pattern | How Graceful Degradation Applies |
+|---------|----------------------------------|
+| [Caching](../idempotency/caches.md) | Fallback tiers when cache misses |
+| [Work Avoidance](../work-avoidance/index.md) | When detection fails, do the work anyway |
+| [Idempotency](../idempotency/index.md) | Safe retries as fallback mechanism |
+| Fail Fast | Complementary: fail fast on preconditions, degrade on runtime |
+| [Error Handling](../../../../operator-manual/github-actions/actions-integration/error-handling.md) | Recovery strategy selection |
+
+---
+
+## Further Reading
+
+- [From 5 Seconds to 5 Milliseconds](../../../../blog/posts/2025-11-29-from-5-seconds-to-5-milliseconds.md) - The cache optimization story that demonstrates this pattern
+- [Cache Considerations](../idempotency/caches.md) - Cache-resilient idempotency strategies

--- a/docs/developer-guide/engineering-practices/patterns/idempotency/caches.md
+++ b/docs/developer-guide/engineering-practices/patterns/idempotency/caches.md
@@ -86,6 +86,8 @@ Some caches restore partial state that breaks assumptions:
 
 ## Strategies for Cache-Resilient Idempotency
 
+These strategies align with the [Graceful Degradation](../graceful-degradation/index.md) pattern: design for cache hits, but survive cache misses.
+
 ### Strategy 1: Verify Cache Validity
 
 Don't trust cache contents blindly:

--- a/docs/developer-guide/engineering-practices/patterns/index.md
+++ b/docs/developer-guide/engineering-practices/patterns/index.md
@@ -26,6 +26,7 @@ This is a growing collection of engineering patterns distilled from real-world D
 | Category | Pattern | Question | Action |
 |----------|---------|----------|--------|
 | Implementation | [**Idempotency**](idempotency/index.md) | "Safe to repeat?" | Make reruns safe |
+| Implementation | [**Graceful Degradation**](graceful-degradation/index.md) | "What if it fails?" | Fallback to slower alternatives |
 | Implementation | **Fail Fast** | "Is something wrong?" | Stop immediately |
 | Implementation | **Prerequisite Checks** | "Can it succeed?" | Validate before starting |
 | Implementation | [**Work Avoidance**](work-avoidance/index.md) | "Already done?" | Skip redundant work |
@@ -55,6 +56,16 @@ Detect when work isn't needed and skip it entirely. Unlike idempotency (which ma
     - Your automation creates noise (version-only PRs, redundant builds)
     - You want to skip operations when nothing meaningful changed
     - You need to filter out volatile metadata before comparing
+
+### [Graceful Degradation](graceful-degradation/index.md)
+
+When the fast path fails, fall back to progressively slower but more reliable alternatives. Degrade performance, not availability.
+
+!!! tip "Start Here If..."
+
+    - Your caches miss sometimes and break workflows
+    - You want systems that survive component failures
+    - You need tiered fallbacks (mount → API → rebuild)
 
 ### [Workflow Patterns](workflow-patterns/index.md)
 

--- a/docs/developer-guide/engineering-practices/patterns/work-avoidance/index.md
+++ b/docs/developer-guide/engineering-practices/patterns/work-avoidance/index.md
@@ -132,4 +132,5 @@ This applies [Volatile Field Exclusion](techniques/volatile-field-exclusion.md) 
 ## Related
 
 - [Idempotency](../idempotency/index.md) - Making operations safe to repeat
+- [Graceful Degradation](../graceful-degradation/index.md) - Fallback when detection fails
 - [Three-Stage Design](../workflow-patterns/three-stage-design.md) - Workflow structure that enables work avoidance

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,7 @@ nav:
                   - Real-World Example: developer-guide/engineering-practices/patterns/idempotency/real-world-example.md
                   - Testing: developer-guide/engineering-practices/patterns/idempotency/testing.md
                   - Cache Considerations: developer-guide/engineering-practices/patterns/idempotency/caches.md
+              - Graceful Degradation: developer-guide/engineering-practices/patterns/graceful-degradation/index.md
               - Work Avoidance:
                   - developer-guide/engineering-practices/patterns/work-avoidance/index.md
                   - Techniques:


### PR DESCRIPTION
## Summary

Closes #47

Add comprehensive documentation for the tiered fallback pattern:

- New pattern page at `docs/developer-guide/engineering-practices/patterns/graceful-degradation/index.md`
- Blog post "The Art of Failing Gracefully" 
- Cross-references from caches, work-avoidance, 5ms blog post, and patterns index
- Added graceful degradation to navigation

## Content Added

### Pattern Documentation
- Overview of graceful degradation principle
- Tiered fallback pattern (Optimal → Acceptable → Guaranteed)
- Real-world examples: cache access, CI/CD dependencies, API resilience
- Code examples in Go and YAML
- Anti-patterns: silent degradation, no guaranteed tier, expensive default
- Implementation checklist
- Relationship to other patterns

### Blog Post
- Introduces the pattern with real numbers
- Links to detailed documentation
- Practical code examples

## Test plan
- [x] Pre-commit hooks pass (markdownlint, mkdocs build)
- [x] All internal links verified by strict mode build