### PR TITLE
refactor: backdate and anonymize release-please blog posts

### DIFF
--- a/docs/blog/posts/2025-11-28-why-release-please-prs-dont-trigger-builds.md
+++ b/docs/blog/posts/2025-11-28-why-release-please-prs-dont-trigger-builds.md
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-03
+date: 2025-11-28
 authors:
   - mark
 categories:
@@ -17,7 +17,7 @@ slug: why-release-please-prs-dont-trigger-builds
 !!! warning "Update: There's a Better Way"
 
     The dual-trigger pattern described below is a **workaround**, not the real fix.
-    See [The Real Fix for Release-Please Triggers](./2025-12-04-the-real-fix-for-release-please-triggers.md)
+    See [The Real Fix for Release-Please Triggers](./2025-12-02-the-real-fix-for-release-please-triggers.md)
     for the proper solution using GitHub App tokens.
 
 The release-please PR looked perfect. Clean changelog. Proper version bump. Ready to merge.

--- a/docs/blog/posts/2025-11-30-what-release-please-cant-do.md
+++ b/docs/blog/posts/2025-11-30-what-release-please-cant-do.md
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-04
+date: 2025-11-30
 authors:
   - mark
 categories:
@@ -24,7 +24,7 @@ Release-please said no.
 
 ## The Goal
 
-Our CONTRIBUTING.md lives in a central repository and gets distributed to 40+ other repos. When we update the guidelines, we wanted:
+Our CONTRIBUTING.md lives in a central repository and gets distributed to 75+ other repos. When we update the guidelines, we wanted:
 
 1. A dedicated changelog for contribution guideline changes
 2. Tags like `contributing-1.0.0`, `contributing-1.1.0`
@@ -99,7 +99,7 @@ The file gets its version updated alongside the main package. Add the annotation
 ```markdown
 ---
 title: Contributing Guidelines
-version: 2.5.5 # x-release-please-version
+version: 1.4.2 # x-release-please-version
 ---
 ```
 

--- a/docs/blog/posts/2025-12-01-the-75-repo-pr-storm.md
+++ b/docs/blog/posts/2025-12-01-the-75-repo-pr-storm.md
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-04
+date: 2025-12-01
 authors:
   - mark
 categories:
@@ -7,16 +7,16 @@ categories:
   - GitHub Actions
   - Engineering Patterns
 description: >-
-  A version bump nearly triggered 41 useless PRs across our organization.
+  A version bump nearly triggered 75 useless PRs across our organization.
   Content-based change detection saved us from PR fatigue.
-slug: the-41-repo-pr-storm
+slug: the-75-repo-pr-storm
 ---
 
-# The 41-Repo PR Storm We Almost Created
+# The 75-Repo PR Storm We Almost Created
 
-The workflow looked perfect. CONTRIBUTING.md in our central repository, automatically distributed to all 41 platform repositories. Any change triggers PRs across the organization.
+The workflow looked perfect. CONTRIBUTING.md in our central repository, automatically distributed to all 75 repositories. Any change triggers PRs across the organization.
 
-Then release-please bumped the version from 2.5.4 to 2.5.5.
+Then release-please bumped the version from 1.4.1 to 1.4.2.
 
 <!-- more -->
 
@@ -28,8 +28,8 @@ We track CONTRIBUTING.md version alongside our platform version using [release-p
 
 ```markdown
 ---
-title: Contributing to Platform Projects
-version: 2.5.5 # x-release-please-version
+title: Contributing Guidelines
+version: 1.4.2 # x-release-please-version
 ---
 ```
 
@@ -51,14 +51,14 @@ fi
 
 This catches everything. Including version-only changes.
 
-The workflow would have created 41 PRs, each containing exactly one line difference:
+The workflow would have created 75 PRs, each containing exactly one line difference:
 
 ```diff
-- version: 2.5.4 # x-release-please-version
-+ version: 2.5.5 # x-release-please-version
+- version: 1.4.1 # x-release-please-version
++ version: 1.4.2 # x-release-please-version
 ```
 
-Forty-one PRs. Forty-one notifications. Forty-one reviews needed. Zero meaningful content.
+Seventy-five PRs. Seventy-five notifications. Seventy-five reviews needed. Zero meaningful content.
 
 ---
 
@@ -67,7 +67,7 @@ Forty-one PRs. Forty-one notifications. Forty-one reviews needed. Zero meaningfu
 We caught it before it ran. The release-please PR merged, the distribution workflow triggered, and we watched the logs:
 
 ```text
-Processing repo 1/41: service-alpha
+Processing repo 1/75: service-alpha
   Changes detected: true
   Creating PR...
 ```
@@ -110,7 +110,7 @@ The sed pattern strips the version line before comparison. If the remaining cont
 Next workflow run:
 
 ```text
-Processed: 41 repositories
+Processed: 75 repositories
 PRs created: 0
 Reason: Version-only changes detected, distribution skipped
 ```
@@ -166,4 +166,4 @@ If the semantic content hasn't changed, the operation probably isn't needed.
 
 ---
 
-*The next time release-please bumps our version, 41 repositories will quietly ignore it. As they should.*
+*The next time release-please bumps our version, 75 repositories will quietly ignore it. As they should.*

--- a/docs/blog/posts/2025-12-02-the-real-fix-for-release-please-triggers.md
+++ b/docs/blog/posts/2025-12-02-the-real-fix-for-release-please-triggers.md
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-04
+date: 2025-12-02
 authors:
   - mark
 categories:
@@ -14,7 +14,7 @@ slug: the-real-fix-for-release-please-triggers
 
 # The Real Fix for Release-Please Triggers
 
-Yesterday I wrote about [why release-please PRs don't trigger builds](./2025-11-27-idempotent-automation.md) and proposed a dual-trigger pattern as the fix. Today I discovered that pattern is a workaround with side effects. Here's the actual solution.
+A few days ago I wrote about [why release-please PRs don't trigger builds](./2025-11-28-why-release-please-prs-dont-trigger-builds.md) and proposed a dual-trigger pattern as the fix. Today I discovered that pattern is a workaround with side effects. Here's the actual solution.
 
 <!-- more -->
 
@@ -22,7 +22,7 @@ Yesterday I wrote about [why release-please PRs don't trigger builds](./2025-11-
 
 ## The Workaround I Documented
 
-The [previous post](./2025-12-03-why-release-please-prs-dont-trigger-builds.md) explained that `GITHUB_TOKEN` actions don't emit workflow events, and proposed adding a secondary `push` trigger:
+The [previous post](./2025-11-28-why-release-please-prs-dont-trigger-builds.md) explained that `GITHUB_TOKEN` actions don't emit workflow events, and proposed adding a secondary `push` trigger:
 
 ```yaml
 on:


### PR DESCRIPTION
## Summary

Backdate and anonymize the release-please blog posts to:
1. Fill calendar gaps in the blog timeline
2. Anonymize specific details that could be traced to real work environments

## Changes

### Date Changes (filling gaps)
| Old Date | New Date | Post |
|----------|----------|------|
| 2025-12-03 | 2025-11-28 | Why Release-Please PRs Don't Trigger Builds |
| 2025-12-04 | 2025-11-30 | What Release-Please Can't Do |
| 2025-12-04 | 2025-12-01 | The 75-Repo PR Storm (was 41-Repo) |
| 2025-12-04 | 2025-12-02 | The Real Fix for Release-Please Triggers |

### Anonymization
- Changed "41 repos" → "75 repos" throughout
- Changed "40+ other repos" → "75+ other repos"
- Changed version numbers from `2.5.x` to `1.4.x`
- Updated internal cross-references between posts

## Test plan
- [x] Pre-commit hooks pass (markdownlint, mkdocs build)
- [x] All internal links verified by strict mode build