### PR TITLE
refactor: convert docs-quality to reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,27 +98,9 @@ jobs:
       always() && !cancelled() &&
       needs.detect-changes.outputs.docs_changed == 'true' &&
       (needs.build-content-analyzer.result == 'success' || needs.build-content-analyzer.result == 'skipped')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: tools/content-analyzer/go.mod
-
-      - name: Build content-analyzer
-        working-directory: tools/content-analyzer
-        run: go build -o content-analyzer ./cmd/content-analyzer/
-
-      - name: Analyze documentation
-        run: |
-          ./tools/content-analyzer/content-analyzer docs/ --format report >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Check readability thresholds
-        run: |
-          ./tools/content-analyzer/content-analyzer docs/ --check
+    uses: ./.github/workflows/docs-quality.yml
+    with:
+      fail_on_threshold: true
 
   build-status:
     name: Build Status

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -1,40 +1,43 @@
 name: Documentation Quality
 
 on:
-  pull_request:
-    paths:
-      - 'docs/**/*.md'
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**/*.md'
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      fail_on_threshold:
+        description: 'Fail the workflow if thresholds are exceeded'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
 
 jobs:
-  readability:
+  analyze:
+    name: Analyze Documentation
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
-          cache-dependency-path: tools/content-analyzer/go.sum
+          go-version-file: tools/content-analyzer/go.mod
+
+      - name: Build content-analyzer
+        working-directory: tools/content-analyzer
+        run: go build -o content-analyzer ./cmd/content-analyzer/
 
       - name: Generate readability report
-        working-directory: tools/content-analyzer
         run: |
-          echo "## Documentation Readability Report" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          go run ./cmd/content-analyzer ../../docs/ --format markdown >> $GITHUB_STEP_SUMMARY
+          ./tools/content-analyzer/content-analyzer docs/ --format report >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Check thresholds
-        working-directory: tools/content-analyzer
+      - name: Check readability thresholds
+        if: inputs.fail_on_threshold
         run: |
-          go run ./cmd/content-analyzer ../../docs/ --check || echo "::warning::Some documentation files exceed readability thresholds"
+          ./tools/content-analyzer/content-analyzer docs/ --check
+
+      - name: Check readability thresholds (warn only)
+        if: ${{ !inputs.fail_on_threshold }}
+        run: |
+          ./tools/content-analyzer/content-analyzer docs/ --check || echo "::warning::Some documentation files exceed readability thresholds"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,27 +119,9 @@ jobs:
       always() && !cancelled() &&
       (needs.detect-changes.outputs.docs_changed == 'true' || inputs.force_all == true) &&
       (needs.build-content-analyzer.result == 'success' || needs.build-content-analyzer.result == 'skipped')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: tools/content-analyzer/go.mod
-
-      - name: Build content-analyzer
-        working-directory: tools/content-analyzer
-        run: go build -o content-analyzer ./cmd/content-analyzer/
-
-      - name: Analyze documentation
-        run: |
-          ./tools/content-analyzer/content-analyzer docs/ --format report >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Check readability thresholds
-        run: |
-          ./tools/content-analyzer/content-analyzer docs/ --check
+    uses: ./.github/workflows/docs-quality.yml
+    with:
+      fail_on_threshold: true
 
   deploy-docs:
     name: Deploy Documentation


### PR DESCRIPTION
## Summary

Convert the standalone `docs-quality.yml` workflow into a reusable workflow that can be called from both `build.yml` and `release.yml`.

## Changes

### docs-quality.yml
- Changed trigger from `pull_request`/`push`/`workflow_dispatch` to `workflow_call`
- Added `fail_on_threshold` input parameter (default: true)
- Supports both strict mode (fail on threshold) and warn-only mode

### build.yml
- Replace inline `analyze-docs` job with call to reusable workflow
- Removes ~20 lines of duplicated code

### release.yml
- Replace inline `analyze-docs` job with call to reusable workflow
- Removes ~20 lines of duplicated code

## Benefits

1. **Single source of truth** - Documentation quality check logic defined once
2. **Easier maintenance** - Updates to the check only need to be made in one place
3. **Configurable** - Callers can choose strict or warn-only mode
4. **Cleaner pipelines** - Build and release workflows focus on their core responsibilities

## Test plan
- [x] Pre-commit hooks pass
- [ ] Build pipeline runs successfully with reusable workflow
- [ ] Release pipeline runs successfully with reusable workflow