### PR TITLE
docs: add cross-reference from principles to pattern guide

### DIFF
--- a/docs/developer-guide/engineering-practices/principles/index.md
+++ b/docs/developer-guide/engineering-practices/principles/index.md
@@ -64,6 +64,10 @@ From the [deployment automation blog post](../../../blog/posts/2025-11-29-from-5
 - **No final tier** - Every fallback can fail
 - **Expensive default** - Using Tier 3 as the happy path
 
+!!! tip "Full Implementation Guide"
+
+    See [Graceful Degradation Pattern](../patterns/graceful-degradation/index.md) for code examples, metrics instrumentation, and detailed implementation checklist.
+
 ---
 
 ## Fail Fast


### PR DESCRIPTION
## Summary
- Links the condensed graceful degradation principle to the full implementation guide

This change was originally committed to the already-merged `docs/issue-47-graceful-degradation` branch by mistake. Cherry-picked to a new branch.