### PR TITLE
revert: remove mike versioning, use GitHub Actions Pages deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,20 +123,16 @@ jobs:
     with:
       fail_on_threshold: true
 
-  deploy-docs:
-    name: Deploy Documentation
-    needs: [release-please, detect-changes, analyze-docs]
+  build-docs:
+    name: Build Documentation
+    needs: [detect-changes, analyze-docs]
     if: |
       always() && !cancelled() &&
       (needs.analyze-docs.result == 'success' || needs.analyze-docs.result == 'skipped')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -157,53 +153,34 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Build documentation
+        run: mkdocs build
 
-      - name: Get version info
-        id: version
-        run: |
-          # Check if release-please created a release in this run
-          if [ "${{ needs.release-please.outputs.site_release_created }}" = "true" ]; then
-            echo "version=${{ needs.release-please.outputs.site_version }}" >> "$GITHUB_OUTPUT"
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "Release detected from release-please outputs"
-            exit 0
-          fi
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
 
-          # Fallback: Check if HEAD commit has a site version tag (for release PR merges)
-          # This handles the case where release-please creates the release but doesn't
-          # report it in outputs (happens when merging release PRs)
-          SITE_TAG=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          if [ -n "$SITE_TAG" ]; then
-            echo "version=$SITE_TAG" >> "$GITHUB_OUTPUT"
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "Release detected from git tag: $SITE_TAG"
-            exit 0
-          fi
-
-          echo "is_release=false" >> "$GITHUB_OUTPUT"
-          echo "No release detected, deploying to latest"
-
-      - name: Deploy versioned docs (release)
-        if: steps.version.outputs.is_release == 'true'
-        run: |
-          echo "Deploying version ${{ steps.version.outputs.version }} as stable"
-          mike deploy --push --update-aliases ${{ steps.version.outputs.version }} stable
-          mike set-default --push stable
-
-      - name: Deploy latest docs (non-release)
-        if: steps.version.outputs.is_release == 'false'
-        run: |
-          echo "Deploying to latest (no release detected)"
-          mike deploy --push --update-aliases latest
+  deploy-docs:
+    name: Deploy Documentation
+    needs: [build-docs]
+    if: needs.build-docs.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   release-status:
     name: Release Status
     runs-on: ubuntu-latest
-    needs: [release-please, detect-changes, build-content-analyzer, analyze-docs, deploy-docs]
+    needs: [release-please, detect-changes, build-content-analyzer, analyze-docs, build-docs, deploy-docs]
     if: always()
     steps:
       - name: Check release results
@@ -215,11 +192,13 @@ jobs:
           echo "| Release Please | - | ${{ needs.release-please.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Content Analyzer | ${{ needs.detect-changes.outputs.content_analyzer_changed }} | ${{ needs.build-content-analyzer.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Doc Analysis | ${{ needs.detect-changes.outputs.docs_changed }} | ${{ needs.analyze-docs.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Build Docs | ${{ needs.detect-changes.outputs.docs_changed }} | ${{ needs.build-docs.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Deploy | - | ${{ needs.deploy-docs.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if any required job failed
         if: |
           needs.build-content-analyzer.result == 'failure' ||
           needs.analyze-docs.result == 'failure' ||
+          needs.build-docs.result == 'failure' ||
           needs.deploy-docs.result == 'failure'
         run: exit 1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,9 +10,6 @@ copyright: |
 extra:
   generator: false
   homepage: https://adaptive-enforcement-lab.com
-  version:
-    provider: mike
-    default: stable
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/adaptive-enforcement-lab

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ mkdocs-material
 pillow
 cairosvg
 mkdocs-rss-plugin
-mike


### PR DESCRIPTION
## Summary
- Remove mike-based documentation versioning in favor of artifact-based GitHub Pages deployment
- Use the modern `actions/upload-pages-artifact` and `actions/deploy-pages` workflow
- Remove mike dependency from requirements.txt

## Why
The versioning system added unnecessary complexity without providing clear user value.

## Changes
- `mkdocs.yml`: Remove version provider config
- `.github/workflows/release.yml`: Split into `build-docs` (artifact upload) and `deploy-docs` (Pages deployment)
- `requirements.txt`: Remove mike dependency

## Required: Repository Settings Change
After merging, update the GitHub Pages source in repository settings:
1. Go to Settings → Pages
2. Under "Build and deployment", change Source from "Deploy from a branch" to **"GitHub Actions"**

## Test plan
- [ ] Verify workflow runs successfully on merge
- [ ] Confirm site deploys without version selector
- [ ] Update repository Pages settings to use GitHub Actions source