### PR TITLE
fix(ci): ensure deploy-docs runs when build-docs succeeds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
   deploy-docs:
     name: Deploy Documentation
     needs: [build-docs]
-    if: needs.build-docs.result == 'success'
+    if: always() && !cancelled() && needs.build-docs.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
## Summary

- Add `always() && !cancelled()` to deploy-docs job condition

## Problem

The deploy-docs job was being skipped even when build-docs succeeded because:

1. Upstream jobs (detect-changes, analyze-docs, build-docs) use `always()` in their conditions
2. When any job in the dependency chain is skipped (e.g., release-please, build-content-analyzer), GitHub Actions doesn't properly evaluate downstream job conditions that lack `always()`
3. The deploy-docs condition `needs.build-docs.result == 'success'` was not being evaluated at all - the job was just skipped

## Fix

Changed from:
```yaml
if: needs.build-docs.result == 'success'
```

To:
```yaml
if: always() && !cancelled() && needs.build-docs.result == 'success'
```

This ensures the condition is actually evaluated regardless of upstream job states.

## Test plan

- [ ] Merge and verify deploy-docs runs on next main push