### PR TITLE
fix(ci): add work avoidance to build-docs job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
     needs: [detect-changes, analyze-docs]
     if: |
       always() && !cancelled() &&
+      (needs.detect-changes.outputs.docs_changed == 'true' || inputs.force_all == true) &&
       (needs.analyze-docs.result == 'success' || needs.analyze-docs.result == 'skipped')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Add `docs_changed` check to `build-docs` job condition

## Problem

The `build-docs` job was running even when no documentation files changed because it only checked if `analyze-docs` succeeded or was skipped, but not whether docs actually changed.

This meant every push to main triggered a full docs build and deploy, wasting CI time.

## Fix

Changed from:
```yaml
if: |
  always() && !cancelled() &&
  (needs.analyze-docs.result == 'success' || needs.analyze-docs.result == 'skipped')
```

To:
```yaml
if: |
  always() && !cancelled() &&
  (needs.detect-changes.outputs.docs_changed == 'true' || inputs.force_all == true) &&
  (needs.analyze-docs.result == 'success' || needs.analyze-docs.result == 'skipped')
```

This matches the pattern used by `build-content-analyzer` and `analyze-docs`.

## Test plan

- [ ] Merge and push a workflow-only change - verify build-docs is skipped
- [ ] Push a docs change - verify build-docs runs
- [ ] Manual trigger with force_all - verify build-docs runs