### PR TITLE
fix(ci): update OTEL export to trigger on Release Pipeline

### DIFF
--- a/.github/workflows/otel-export.yml
+++ b/.github/workflows/otel-export.yml
@@ -2,7 +2,9 @@ name: Export OpenTelemetry Traces to Dash0
 on:
   workflow_run:
     workflows:
-      - "Deploy MkDocs to GitHub Pages"
+      - "Build Pipeline"
+      - "Release Pipeline"
+      - "Documentation Quality"
     types:
       - completed
 jobs:


### PR DESCRIPTION
## Summary

- Update `otel-export.yml` to trigger on `Release Pipeline` instead of the old `Deploy MkDocs to GitHub Pages` workflow name

## Problem

The OTEL export workflow was not triggering because it was listening for a workflow named "Deploy MkDocs to GitHub Pages" which was renamed to "Release Pipeline".

## Test plan

- [ ] Merge and verify OTEL export triggers after the next Release Pipeline run