### PR TITLE
chore: enable always-update for release-please PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": false,
   "tag-separator": "-",
+  "always-update": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

- Add `"always-update": true` to release-please config

## Problem

Release PRs become out-of-date when new commits are added to main, requiring manual updates.

## Solution

Enable `always-update` option which automatically updates existing release PRs when changes are added, not just when release notes change.

Ref: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#bootstrap-manually

> if true, always update existing pull requests when changes are added, instead of only when the release notes change.