### PR TITLE
feat: upgrade to readability v0.4.0 with automatic summary

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -20,18 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Analyze documentation
-        id: readability
-        uses: adaptive-enforcement-lab/readability@0.3.2
+        uses: adaptive-enforcement-lab/readability@0.4.0
         with:
           path: docs/
-          format: report
           check: ${{ inputs.fail_on_threshold }}
-
-      - name: Add report to summary
-        run: echo "${{ steps.readability.outputs.report }}" | jq -r '
-          "## Documentation Readability Report",
-          "",
-          "| File | Grade | ARI | Fog | Ease | Status |",
-          "|------|-------|-----|-----|------|--------|",
-          (.[] | "| \(.file) | \(.readability.flesch_kincaid_grade | . * 10 | round / 10) | \(.readability.ari | . * 10 | round / 10) | \(.readability.gunning_fog | . * 10 | round / 10) | \(.readability.flesch_reading_ease | . * 10 | round / 10) | \(.status) |")
-        ' >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-readability.sh
+++ b/scripts/check-readability.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-READABILITY_VERSION="0.3.2"
+READABILITY_VERSION="0.4.0"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/readability"
 BINARY="$CACHE_DIR/readability"
 


### PR DESCRIPTION
## Summary

Adds automatic job summary generation to eliminate boilerplate in consumer workflows.

Closes #22

## Before

Users had to manually format and write the summary:

```yaml
- name: Analyze documentation
  id: readability
  uses: adaptive-enforcement-lab/readability@0.3.2
  with:
    path: docs/
    check: true

- name: Add report to summary
  run: echo "${{ steps.readability.outputs.report }}" | jq -r '
    "## Documentation Readability Report",
    "",
    "| File | Grade | ARI | Fog | Ease | Status |",
    "|------|-------|-----|-----|------|--------|",
    (.[] | "| \(.file) | ...")
  ' >> "$GITHUB_STEP_SUMMARY"
```

## After

Zero-config - summary is generated automatically:

```yaml
- name: Analyze documentation
  uses: adaptive-enforcement-lab/readability@0.4.0
  with:
    path: docs/
    check: true
```

## New Inputs

| Input | Type | Default | Description |
|-------|------|---------|-------------|
| `summary` | boolean | `true` | Write formatted report to job summary |
| `summary-title` | string | `Documentation Readability Report` | Title for the summary section |

## Generated Summary

The action writes a formatted markdown report to `$GITHUB_STEP_SUMMARY`:

> ## Documentation Readability Report
>
> | File | Grade | ARI | Fog | Ease | Status |
> |------|-------|-----|-----|------|--------|
> | docs/index.md | 6.7 | 5.7 | 7.9 | 58.4 | pass |
> | docs/about.md | 8.2 | 9.1 | 10.2 | 45.3 | pass |
>
> _Files analyzed: 2 | Passed: 2 | Failed: 0_

## Test plan

- [ ] CI passes
- [ ] Test in adaptive-enforcement-lab-com after merge