### PR TITLE
chore: use floating major tag for readability action

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Analyze documentation
-        uses: adaptive-enforcement-lab/readability@0.6.0
+        uses: adaptive-enforcement-lab/readability@0
         with:
           path: docs/
           check: ${{ inputs.fail_on_threshold }}


### PR DESCRIPTION
## Summary

Switch from pinned version (`@0.6.0`) to floating major tag (`@0`) for automatic updates.

## Rationale

The readability action now maintains a floating major tag that always points to the latest release within that major version. This allows consumers to automatically receive bug fixes and new features without updating the workflow.

## Change

```diff
-- uses: adaptive-enforcement-lab/readability@0.6.0
+- uses: adaptive-enforcement-lab/readability@0
```