### PR TITLE
docs: add Go CLI architecture guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,9 @@ repos:
       - id: markdownlint
         args: ["--config", ".markdownlint.yml"]
         files: \.md$
+        exclude: ^CHANGELOG\.md$
   - repo: https://github.com/adaptive-enforcement-lab/readability
-    rev: 0.6.0
+    rev: "0"
     hooks:
       - id: readability-docs
         name: check documentation readability

--- a/docs/developer-guide/go-cli-architecture/command-architecture/index.md
+++ b/docs/developer-guide/go-cli-architecture/command-architecture/index.md
@@ -1,0 +1,68 @@
+# Command Architecture
+
+Design command structures that are intuitive, composable, and maintainable.
+
+---
+
+## Overview
+
+A well-designed CLI has commands that work both independently and as part of larger workflows. This section covers:
+
+- **[Orchestrator Pattern](orchestrator-pattern.md)** - Coordinate multi-step workflows
+- **[Subcommand Design](subcommand-design.md)** - Build independently useful commands
+- **[Input/Output Contracts](io-contracts.md)** - Design for pipelines and automation
+
+---
+
+## The Orchestrator Pattern
+
+For complex workflows, use a single entry point that coordinates subcommands:
+
+```mermaid
+graph LR
+    subgraph Orchestrator["orchestrate command"]
+        Start[Start] --> Check[check]
+        Check -->|Cache Valid| Skip[Skip Rebuild]
+        Check -->|Cache Invalid| Rebuild[rebuild]
+        Rebuild --> Select[select]
+        Select --> Restart[restart]
+        Restart --> Done[Done]
+        Skip --> Done
+    end
+
+    style Orchestrator fill:#65d9ef,color:#1b1d1e
+```
+
+---
+
+## Command Hierarchy
+
+```text
+myctl
+├── orchestrate          # Main workflow
+├── check                # Cache status
+├── rebuild              # Force cache rebuild
+├── select               # List deployments
+├── restart              # Restart deployments
+├── version              # Show version info
+└── completion           # Shell completion scripts
+    ├── bash
+    ├── zsh
+    └── fish
+```
+
+---
+
+## Best Practices
+
+| Practice | Description |
+|----------|-------------|
+| **Flat hierarchy** | Avoid deeply nested subcommands (max 2 levels) |
+| **Verb-noun ordering** | `myctl restart deployment` not `myctl deployment restart` |
+| **Consistent flags** | Use same flag names across commands |
+| **Hidden internal commands** | Mark debugging commands as hidden |
+| **Exit codes** | Use consistent exit codes (0=success, 1=failure, 2=usage error) |
+
+---
+
+*Design commands for both humans and scripts.*

--- a/docs/developer-guide/go-cli-architecture/command-architecture/io-contracts.md
+++ b/docs/developer-guide/go-cli-architecture/command-architecture/io-contracts.md
@@ -1,0 +1,185 @@
+# Input/Output Contracts
+
+Design commands to work in pipelines and automation.
+
+---
+
+## Structured Output for Piping
+
+Design commands to work in pipelines:
+
+```go
+package cmd
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+
+    "github.com/spf13/cobra"
+)
+
+type SelectResult struct {
+    Deployments []string `json:"deployments"`
+    Namespace   string   `json:"namespace"`
+    Count       int      `json:"count"`
+}
+
+var selectCmd = &cobra.Command{
+    Use:   "select",
+    Short: "Select deployments for restart",
+    Long: `Select deployments that need to be restarted based on cache changes.
+
+Output can be piped to other commands:
+  myctl select --output names | xargs -I {} kubectl rollout restart deployment/{}`,
+    RunE: runSelect,
+}
+
+var outputFormat string
+
+func init() {
+    selectCmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table, json, names")
+    rootCmd.AddCommand(selectCmd)
+}
+
+func runSelect(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+
+    deployments, err := selectDeployments(ctx)
+    if err != nil {
+        return err
+    }
+
+    result := SelectResult{
+        Deployments: deployments,
+        Namespace:   namespace,
+        Count:       len(deployments),
+    }
+
+    switch outputFormat {
+    case "json":
+        enc := json.NewEncoder(os.Stdout)
+        enc.SetIndent("", "  ")
+        return enc.Encode(result)
+
+    case "names":
+        // One name per line for piping
+        for _, d := range deployments {
+            fmt.Println(d)
+        }
+
+    default: // table
+        if len(deployments) == 0 {
+            fmt.Println("No deployments selected")
+            return nil
+        }
+        fmt.Printf("NAMESPACE\tDEPLOYMENT\n")
+        for _, d := range deployments {
+            fmt.Printf("%s\t%s\n", namespace, d)
+        }
+    }
+
+    return nil
+}
+```
+
+---
+
+## Pipeline Examples
+
+```bash
+# Pipe deployment names to restart
+myctl select --output names | myctl restart -
+
+# Filter with grep before restarting
+myctl select --output names | grep "api-" | myctl restart -
+
+# Export to JSON for processing
+myctl select --output json | jq '.deployments[]'
+
+# Use with xargs
+myctl select --output names | xargs -I {} kubectl describe deployment/{}
+```
+
+---
+
+## Output Format Guidelines
+
+| Format | Use Case | Example |
+|--------|----------|---------|
+| `table` | Human reading in terminal | Default, formatted columns |
+| `json` | Scripting and parsing | `jq` processing |
+| `names` | Piping to other commands | One item per line |
+| `yaml` | Configuration export | kubectl-style output |
+| `wide` | Extended information | Additional columns |
+
+---
+
+## Input Flexibility
+
+Support multiple input methods:
+
+```go
+func getDeploymentsFromInput(cmd *cobra.Command, args []string) ([]string, error) {
+    // Priority 1: Explicit arguments
+    if len(args) > 0 && args[0] != "-" {
+        return args, nil
+    }
+
+    // Priority 2: Stdin (with - argument)
+    if len(args) == 1 && args[0] == "-" {
+        return readFromStdin()
+    }
+
+    // Priority 3: Interactive selection (if TTY)
+    if isatty.IsTerminal(os.Stdin.Fd()) {
+        return interactiveSelect()
+    }
+
+    return nil, fmt.Errorf("no deployments specified")
+}
+```
+
+---
+
+## Quiet and Verbose Modes
+
+```go
+var (
+    quiet   bool
+    verbose bool
+)
+
+func init() {
+    rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress non-essential output")
+    rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+}
+
+func log(format string, args ...interface{}) {
+    if !quiet {
+        fmt.Printf(format+"\n", args...)
+    }
+}
+
+func debug(format string, args ...interface{}) {
+    if verbose {
+        fmt.Printf("[DEBUG] "+format+"\n", args...)
+    }
+}
+```
+
+---
+
+## Best Practices
+
+| Practice | Description |
+|----------|-------------|
+| **Default to table** | Human-readable output by default |
+| **Support JSON** | Enable scripting and automation |
+| **One item per line** | For `names` format, enable easy piping |
+| **Quiet mode** | Suppress non-essential output for scripts |
+| **Consistent formats** | Use same format options across commands |
+
+---
+
+*Design for both humans and scripts: table for eyes, JSON/names for pipes.*

--- a/docs/developer-guide/go-cli-architecture/command-architecture/orchestrator-pattern.md
+++ b/docs/developer-guide/go-cli-architecture/command-architecture/orchestrator-pattern.md
@@ -1,0 +1,236 @@
+# Orchestrator Pattern
+
+Coordinate multi-step workflows through a single entry point.
+
+---
+
+## Implementation
+
+```go
+package cmd
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/spf13/cobra"
+)
+
+var orchestrateCmd = &cobra.Command{
+    Use:   "orchestrate",
+    Short: "Run the full orchestration workflow",
+    Long: `Execute the complete workflow: check cache, rebuild if needed,
+select deployments, and trigger restarts.
+
+This is the main entry point for automated execution.`,
+    RunE: runOrchestrate,
+}
+
+func runOrchestrate(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+
+    // Step 1: Check cache
+    fmt.Println("Checking cache...")
+    valid, err := checkCache(ctx)
+    if err != nil {
+        return fmt.Errorf("cache check failed: %w", err)
+    }
+
+    if valid {
+        fmt.Println("Cache valid, nothing to do")
+        return nil
+    }
+
+    // Step 2: Rebuild cache
+    fmt.Println("Rebuilding cache...")
+    if err := rebuildCache(ctx); err != nil {
+        return fmt.Errorf("cache rebuild failed: %w", err)
+    }
+
+    // Step 3: Select deployments
+    fmt.Println("Selecting deployments...")
+    deployments, err := selectDeployments(ctx)
+    if err != nil {
+        return fmt.Errorf("deployment selection failed: %w", err)
+    }
+
+    if len(deployments) == 0 {
+        fmt.Println("No deployments need restart")
+        return nil
+    }
+
+    // Step 4: Restart deployments
+    fmt.Printf("Restarting %d deployments...\n", len(deployments))
+    if err := restartDeployments(ctx, deployments); err != nil {
+        return fmt.Errorf("restart failed: %w", err)
+    }
+
+    fmt.Println("Orchestration complete")
+    return nil
+}
+```
+
+---
+
+## Rebuild Command
+
+The rebuild command forces a cache rebuild:
+
+```go
+package cmd
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/spf13/cobra"
+)
+
+var rebuildCmd = &cobra.Command{
+    Use:   "rebuild",
+    Short: "Force rebuild of the cache",
+    Long: `Rebuild the cache from scratch, ignoring any existing cached data.
+
+Use this when you suspect the cache is corrupted or out of sync.`,
+    RunE: runRebuild,
+}
+
+var forceRebuild bool
+
+func init() {
+    rebuildCmd.Flags().BoolVar(&forceRebuild, "force", false, "Skip confirmation prompt")
+    rootCmd.AddCommand(rebuildCmd)
+}
+
+func runRebuild(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+
+    if !forceRebuild {
+        fmt.Print("This will invalidate all cached data. Continue? [y/N]: ")
+        var response string
+        fmt.Scanln(&response)
+        if response != "y" && response != "Y" {
+            fmt.Println("Aborted")
+            return nil
+        }
+    }
+
+    fmt.Println("Rebuilding cache...")
+    if err := rebuildCache(ctx); err != nil {
+        return fmt.Errorf("rebuild failed: %w", err)
+    }
+
+    fmt.Println("Cache rebuilt successfully")
+    return nil
+}
+```
+
+---
+
+## Error Handling and Exit Codes
+
+### Consistent Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Operation failed or condition not met |
+| 2 | Invalid usage or configuration error |
+| 3 | Partial failure (some operations succeeded) |
+
+### ExitError Type
+
+```go
+package cmd
+
+import (
+    "fmt"
+    "os"
+)
+
+// ExitError wraps an error with an exit code
+type ExitError struct {
+    Err  error
+    Code int
+}
+
+func (e *ExitError) Error() string {
+    return e.Err.Error()
+}
+
+// Execute handles ExitError for proper exit codes
+func Execute() {
+    if err := rootCmd.Execute(); err != nil {
+        if exitErr, ok := err.(*ExitError); ok {
+            fmt.Fprintln(os.Stderr, exitErr.Error())
+            os.Exit(exitErr.Code)
+        }
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+}
+
+// Usage in commands
+func runCheck(cmd *cobra.Command, args []string) error {
+    valid, err := performCacheCheck(cmd.Context())
+    if err != nil {
+        return &ExitError{Err: err, Code: 2}
+    }
+    if !valid {
+        return &ExitError{Err: fmt.Errorf("cache needs rebuild"), Code: 1}
+    }
+    return nil
+}
+```
+
+---
+
+## Dry Run Mode
+
+!!! tip "Always Implement Dry Run"
+
+    Users expect `--dry-run` to preview changes safely. This builds trust and enables CI integration without side effects.
+
+Add a global `--dry-run` flag that shows what would happen:
+
+```go
+package cmd
+
+import (
+    "fmt"
+
+    "github.com/spf13/cobra"
+)
+
+var dryRun bool
+
+func init() {
+    rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Show what would be done")
+}
+
+func runRestart(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+
+    deployments, err := selectDeployments(ctx)
+    if err != nil {
+        return err
+    }
+
+    for _, d := range deployments {
+        if dryRun {
+            fmt.Printf("[dry-run] Would restart deployment: %s\n", d)
+            continue
+        }
+        fmt.Printf("Restarting deployment: %s\n", d)
+        if err := restartDeployment(ctx, d); err != nil {
+            return fmt.Errorf("failed to restart %s: %w", d, err)
+        }
+    }
+
+    return nil
+}
+```
+
+---
+
+*The orchestrator coordinates; individual commands do the work.*

--- a/docs/developer-guide/go-cli-architecture/command-architecture/subcommand-design.md
+++ b/docs/developer-guide/go-cli-architecture/command-architecture/subcommand-design.md
@@ -1,0 +1,211 @@
+# Subcommand Design
+
+Each subcommand should be independently useful.
+
+---
+
+## Check Command
+
+```go
+package cmd
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "os"
+    "time"
+
+    "github.com/spf13/cobra"
+)
+
+type CheckResult struct {
+    Valid     bool   `json:"valid"`
+    Reason    string `json:"reason,omitempty"`
+    Timestamp string `json:"timestamp"`
+}
+
+var checkCmd = &cobra.Command{
+    Use:   "check",
+    Short: "Check if cache rebuild is needed",
+    Long: `Check the current cache state and determine if a rebuild is required.
+
+Exit codes:
+  0 - Cache is valid
+  1 - Cache needs rebuild
+  2 - Error occurred`,
+    RunE: runCheck,
+}
+
+var outputJSON bool
+
+func init() {
+    checkCmd.Flags().BoolVar(&outputJSON, "json", false, "Output result as JSON")
+    rootCmd.AddCommand(checkCmd)
+}
+
+func runCheck(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+
+    valid, reason, err := performCacheCheck(ctx)
+    if err != nil {
+        return err
+    }
+
+    result := CheckResult{
+        Valid:     valid,
+        Reason:    reason,
+        Timestamp: time.Now().Format(time.RFC3339),
+    }
+
+    if outputJSON {
+        enc := json.NewEncoder(os.Stdout)
+        enc.SetIndent("", "  ")
+        return enc.Encode(result)
+    }
+
+    if valid {
+        fmt.Println("Cache is valid")
+        return nil
+    }
+
+    fmt.Printf("Cache needs rebuild: %s\n", reason)
+    os.Exit(1)
+    return nil
+}
+```
+
+---
+
+## Command Registration
+
+Organize command registration cleanly:
+
+```go
+// cmd/root.go
+package cmd
+
+import (
+    "github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+    Use:   "myctl",
+    Short: "Kubernetes orchestration CLI",
+}
+
+func init() {
+    // Global flags
+    rootCmd.PersistentFlags().StringP("namespace", "n", "default", "Kubernetes namespace")
+    rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
+    rootCmd.PersistentFlags().Bool("dry-run", false, "Show what would be done")
+
+    // Register subcommands
+    rootCmd.AddCommand(orchestrateCmd)
+    rootCmd.AddCommand(checkCmd)
+    rootCmd.AddCommand(rebuildCmd)
+    rootCmd.AddCommand(selectCmd)
+    rootCmd.AddCommand(restartCmd)
+    rootCmd.AddCommand(versionCmd)
+}
+
+func Execute() error {
+    return rootCmd.Execute()
+}
+```
+
+---
+
+## Reading from Stdin
+
+Support stdin input with `-` argument for piping:
+
+```go
+package cmd
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+    "strings"
+
+    "github.com/spf13/cobra"
+)
+
+var restartCmd = &cobra.Command{
+    Use:   "restart [deployments...]",
+    Short: "Restart deployments",
+    Long: `Restart the specified deployments.
+
+Deployment names can be provided as arguments or piped via stdin:
+  myctl select --output names | myctl restart -`,
+    RunE: runRestart,
+}
+
+func runRestart(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+
+    var deployments []string
+
+    // Check if reading from stdin
+    if len(args) == 1 && args[0] == "-" {
+        scanner := bufio.NewScanner(os.Stdin)
+        for scanner.Scan() {
+            line := strings.TrimSpace(scanner.Text())
+            if line != "" {
+                deployments = append(deployments, line)
+            }
+        }
+        if err := scanner.Err(); err != nil {
+            return fmt.Errorf("failed to read stdin: %w", err)
+        }
+    } else {
+        deployments = args
+    }
+
+    if len(deployments) == 0 {
+        return fmt.Errorf("no deployments specified")
+    }
+
+    for _, d := range deployments {
+        fmt.Printf("Restarting %s...\n", d)
+        if err := restartDeployment(ctx, d); err != nil {
+            return err
+        }
+    }
+
+    return nil
+}
+```
+
+---
+
+## Hidden Commands
+
+Mark debugging or internal commands as hidden:
+
+```go
+var debugCmd = &cobra.Command{
+    Use:    "debug",
+    Short:  "Internal debugging commands",
+    Hidden: true,  // Won't appear in help
+}
+
+var dumpCacheCmd = &cobra.Command{
+    Use:   "dump-cache",
+    Short: "Dump internal cache state",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        // Debug implementation
+        return nil
+    },
+}
+
+func init() {
+    debugCmd.AddCommand(dumpCacheCmd)
+    rootCmd.AddCommand(debugCmd)
+}
+```
+
+---
+
+*Each command should work independently but compose well with others.*

--- a/docs/developer-guide/go-cli-architecture/framework-selection/cli-frameworks.md
+++ b/docs/developer-guide/go-cli-architecture/framework-selection/cli-frameworks.md
@@ -1,0 +1,215 @@
+# CLI Frameworks
+
+Compare Go CLI frameworks to choose the right foundation for your tool.
+
+---
+
+## Cobra
+
+The de facto standard for Go CLIs. Powers kubectl, docker, gh, and most Kubernetes ecosystem tools.
+
+```go
+package cmd
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+    Use:   "myctl",
+    Short: "Kubernetes orchestration CLI",
+    Long:  `A CLI for managing deployments and cache operations.`,
+}
+
+func Execute() {
+    if err := rootCmd.Execute(); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+}
+
+func init() {
+    rootCmd.PersistentFlags().StringP("namespace", "n", "default", "Kubernetes namespace")
+    rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
+}
+```
+
+**Strengths:**
+
+- Mature ecosystem with extensive documentation
+- Built-in help generation, shell completion
+- Hierarchical command structure
+- Pairs well with Viper for configuration
+
+**When to use:** Most Kubernetes-native CLIs. Default choice unless you have specific reasons otherwise.
+
+### Help Text Generation
+
+Cobra automatically generates help text from your command definitions:
+
+```go
+var checkCmd = &cobra.Command{
+    Use:   "check [flags]",
+    Short: "Check cache status",
+    Long: `Check the current cache state and determine if a rebuild is required.
+
+The check command validates the cache against the current state of
+deployments in the cluster and reports whether action is needed.
+
+Exit codes:
+  0 - Cache is valid
+  1 - Cache needs rebuild
+  2 - Error occurred`,
+    Example: `  # Check cache status
+  myctl check
+
+  # Check with JSON output
+  myctl check --json
+
+  # Check specific namespace
+  myctl check -n production`,
+    RunE: runCheck,
+}
+```
+
+---
+
+## urfave/cli
+
+Simpler API, good for straightforward CLIs without deep command hierarchies.
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "os"
+
+    "github.com/urfave/cli/v2"
+)
+
+func main() {
+    app := &cli.App{
+        Name:  "myctl",
+        Usage: "Kubernetes orchestration CLI",
+        Flags: []cli.Flag{
+            &cli.StringFlag{
+                Name:    "namespace",
+                Aliases: []string{"n"},
+                Value:   "default",
+                Usage:   "Kubernetes namespace",
+            },
+        },
+        Commands: []*cli.Command{
+            {
+                Name:  "check",
+                Usage: "Check cache status",
+                Action: func(c *cli.Context) error {
+                    fmt.Println("Checking cache...")
+                    return nil
+                },
+            },
+        },
+    }
+
+    if err := app.Run(os.Args); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+**Strengths:**
+
+- Single-file friendly
+- Less boilerplate for simple CLIs
+- Good for scripts evolving into tools
+
+**When to use:** Simple CLIs with few commands, prototypes.
+
+---
+
+## Kong
+
+Type-safe CLI parsing using struct tags. Newer but gaining adoption.
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/alecthomas/kong"
+)
+
+type CLI struct {
+    Namespace string `short:"n" default:"default" help:"Kubernetes namespace"`
+    Verbose   bool   `help:"Enable verbose output"`
+
+    Check   CheckCmd   `cmd:"" help:"Check cache status"`
+    Rebuild RebuildCmd `cmd:"" help:"Rebuild cache"`
+}
+
+type CheckCmd struct {
+    All bool `help:"Check all namespaces"`
+}
+
+func (c *CheckCmd) Run() error {
+    fmt.Println("Checking cache...")
+    return nil
+}
+
+type RebuildCmd struct{}
+
+func (r *RebuildCmd) Run() error {
+    fmt.Println("Rebuilding cache...")
+    return nil
+}
+
+func main() {
+    var cli CLI
+    ctx := kong.Parse(&cli)
+    err := ctx.Run()
+    ctx.FatalIfErrorf(err)
+}
+```
+
+**Strengths:**
+
+- Type-safe command definitions
+- Compile-time validation of CLI structure
+- Clean struct-based API
+
+**When to use:** New projects that value type safety, teams familiar with struct tags.
+
+---
+
+## Best Practices
+
+### Flag Naming
+
+| Pattern | Example | Notes |
+|---------|---------|-------|
+| Kebab-case for flags | `--dry-run` | Standard convention |
+| Short flags for common options | `-n` for namespace | Match kubectl patterns |
+| Avoid abbreviations | `--namespace` not `--ns` | Clarity over brevity |
+
+### Required vs Optional
+
+```go
+// Required flags
+cmd.MarkFlagRequired("name")
+
+// Mutually exclusive
+cmd.MarkFlagsMutuallyExclusive("file", "stdin")
+
+// Required together
+cmd.MarkFlagsRequiredTogether("username", "password")
+```
+
+---
+
+*Match kubectl conventions. Your users already know them.*

--- a/docs/developer-guide/go-cli-architecture/framework-selection/index.md
+++ b/docs/developer-guide/go-cli-architecture/framework-selection/index.md
@@ -1,0 +1,46 @@
+# Framework Selection
+
+Choose the right CLI framework and configuration approach for your Go CLI.
+
+---
+
+## Overview
+
+Building a Kubernetes-native CLI requires thoughtful framework selection. The right choice depends on your complexity needs, ecosystem alignment, and team preferences.
+
+This section covers:
+
+- **[CLI Frameworks](cli-frameworks.md)** - Cobra, urfave/cli, and Kong compared
+- **[Configuration with Viper](viper-configuration.md)** - Layered configuration management
+
+---
+
+## Quick Recommendation
+
+!!! success "Default Choice"
+
+    For Kubernetes-native CLIs, use **Cobra + Viper**. It powers kubectl, docker, gh, and most ecosystem tools. Your users already know the patterns.
+
+| Need | Recommendation |
+|------|----------------|
+| Kubernetes ecosystem CLI | **Cobra** + Viper |
+| Simple utility | **urfave/cli** |
+| Type-safe struct definitions | **Kong** |
+
+---
+
+## Decision Matrix
+
+| Criteria | Cobra | urfave/cli | Kong |
+|----------|-------|------------|------|
+| Ecosystem maturity | High | Medium | Growing |
+| Learning curve | Medium | Low | Low |
+| Type safety | Low | Low | High |
+| Kubernetes alignment | High | Medium | Medium |
+| Configuration integration | Excellent (Viper) | Good | Good |
+| Shell completion | Built-in | Plugin | Built-in |
+| Nested subcommands | Excellent | Good | Good |
+
+---
+
+*Choose tools that match kubectl conventions. Your users already know them.*

--- a/docs/developer-guide/go-cli-architecture/framework-selection/viper-configuration.md
+++ b/docs/developer-guide/go-cli-architecture/framework-selection/viper-configuration.md
@@ -1,0 +1,193 @@
+# Configuration with Viper
+
+Layer configuration sources for flexible CLI behavior.
+
+---
+
+## Configuration Hierarchy
+
+Viper integrates seamlessly with Cobra for layered configuration:
+
+```mermaid
+graph TB
+    subgraph Priority["Configuration Priority (highest to lowest)"]
+        Flags[Command-line Flags]
+        Env[Environment Variables]
+        Config[Config File]
+        Defaults[Defaults]
+    end
+
+    Flags --> Env --> Config --> Defaults
+
+    style Priority fill:#65d9ef,color:#1b1d1e
+```
+
+---
+
+## Implementation
+
+```go
+package cmd
+
+import (
+    "fmt"
+    "os"
+    "strings"
+
+    "github.com/spf13/cobra"
+    "github.com/spf13/viper"
+)
+
+var cfgFile string
+
+var rootCmd = &cobra.Command{
+    Use:   "myctl",
+    Short: "Kubernetes orchestration CLI",
+    PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+        return initConfig()
+    },
+}
+
+func init() {
+    rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: $HOME/.myctl.yaml)")
+    rootCmd.PersistentFlags().StringP("namespace", "n", "default", "Kubernetes namespace")
+    rootCmd.PersistentFlags().String("kubeconfig", "", "Path to kubeconfig file")
+    rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
+
+    // Bind flags to viper
+    viper.BindPFlag("namespace", rootCmd.PersistentFlags().Lookup("namespace"))
+    viper.BindPFlag("kubeconfig", rootCmd.PersistentFlags().Lookup("kubeconfig"))
+    viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+}
+
+func initConfig() error {
+    if cfgFile != "" {
+        viper.SetConfigFile(cfgFile)
+    } else {
+        home, err := os.UserHomeDir()
+        if err != nil {
+            return err
+        }
+        viper.AddConfigPath(home)
+        viper.AddConfigPath(".")
+        viper.SetConfigName(".myctl")
+        viper.SetConfigType("yaml")
+    }
+
+    // Environment variable binding
+    viper.SetEnvPrefix("MYCTL")
+    viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+    viper.AutomaticEnv()
+
+    // Read config file (ignore if not found)
+    if err := viper.ReadInConfig(); err != nil {
+        if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+            return fmt.Errorf("error reading config: %w", err)
+        }
+    }
+
+    return nil
+}
+
+func Execute() {
+    if err := rootCmd.Execute(); err != nil {
+        os.Exit(1)
+    }
+}
+```
+
+---
+
+## Example Config File
+
+```yaml
+# ~/.myctl.yaml
+namespace: production
+kubeconfig: ~/.kube/config
+verbose: false
+
+cache:
+  ttl: 300
+  backend: redis
+  redis:
+    host: localhost
+    port: 6379
+```
+
+---
+
+## Accessing Configuration
+
+```go
+func runCheck(cmd *cobra.Command, args []string) error {
+    namespace := viper.GetString("namespace")
+    verbose := viper.GetBool("verbose")
+    cacheTTL := viper.GetInt("cache.ttl")
+
+    if verbose {
+        fmt.Printf("Using namespace: %s\n", namespace)
+        fmt.Printf("Cache TTL: %d seconds\n", cacheTTL)
+    }
+
+    // ... check logic
+    return nil
+}
+```
+
+---
+
+## Environment Variable Patterns
+
+### Standard Kubernetes Variables
+
+Support the variables users expect:
+
+```go
+func init() {
+    // Standard kubeconfig handling
+    if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
+        viper.SetDefault("kubeconfig", kubeconfig)
+    }
+
+    // Namespace from environment (Kubernetes convention)
+    if ns := os.Getenv("NAMESPACE"); ns != "" {
+        viper.SetDefault("namespace", ns)
+    }
+}
+```
+
+### In-Cluster Detection
+
+```go
+func isInCluster() bool {
+    _, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    return err == nil
+}
+
+func getDefaultNamespace() string {
+    // In-cluster: read from mounted secret
+    if isInCluster() {
+        if ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+            return string(ns)
+        }
+    }
+    // Out-of-cluster: use default
+    return "default"
+}
+```
+
+---
+
+## Configuration Best Practices
+
+| Practice | Description |
+|----------|-------------|
+| **Environment prefix** | Use `MYCTL_` prefix for all env vars |
+| **Nested config** | Support `cache.ttl` style nested values |
+| **Config file optional** | Never require a config file to exist |
+| **Respect KUBECONFIG** | Always honor the standard env var |
+| **Document all options** | List all config options in `--help` |
+
+---
+
+*Layer configuration for flexibility: flags override env vars override config files.*

--- a/docs/developer-guide/go-cli-architecture/index.md
+++ b/docs/developer-guide/go-cli-architecture/index.md
@@ -1,0 +1,184 @@
+# Go CLI Architecture
+
+Build orchestration CLIs in Go for Kubernetes-native automation.
+
+This guide covers the meta-architecture for building custom CLIs that integrate with Kubernetes and workflow engines. These patterns apply whether you're building deployment tools, cache managers, or any automation that needs to interact with cluster resources.
+
+---
+
+## When to Use Go CLIs
+
+!!! tip "Go vs Shell Scripts"
+
+    Start with shell scripts for prototyping. Graduate to Go when you need type safety, testability, or complex orchestration logic.
+
+**Use Go when you need:**
+
+- Direct Kubernetes API access with type-safe clients
+- Complex orchestration logic across multiple resources
+- Reusable tooling packaged as container images
+- Performance-critical operations (milliseconds matter)
+- Long-running controllers or operators
+
+**Use shell scripts when you need:**
+
+- Simple glue logic between existing tools
+- Quick prototypes or one-off operations
+- kubectl-based workflows without custom logic
+- CI/CD steps that primarily call other CLIs
+
+---
+
+## Architecture Overview
+
+```mermaid
+graph TB
+    subgraph CLI["CLI Layer"]
+        Root[root.go<br/>Cobra Root Command]
+        Orch[orchestrate.go<br/>Workflow Entry Point]
+        Sub1[check.go<br/>Subcommand]
+        Sub2[rebuild.go<br/>Subcommand]
+        Sub3[select.go<br/>Subcommand]
+    end
+
+    subgraph Pkg["Business Logic Layer"]
+        Cache[pkg/cache<br/>Cache Management]
+        K8s[pkg/k8s<br/>Client Wrapper]
+        Selector[pkg/selector<br/>Business Logic]
+        Restarter[pkg/restarter<br/>Deployment Logic]
+    end
+
+    subgraph External["External Systems"]
+        API[Kubernetes API]
+        Argo[Argo Workflows]
+        Store[Cache Store]
+    end
+
+    Root --> Orch
+    Orch --> Sub1
+    Orch --> Sub2
+    Orch --> Sub3
+    Sub1 --> Cache
+    Sub2 --> Cache
+    Sub3 --> Selector
+    Selector --> Restarter
+    Cache --> K8s
+    Selector --> K8s
+    Restarter --> K8s
+    K8s --> API
+    K8s --> Argo
+    Cache --> Store
+
+    %% CLI Layer nodes - cyan
+    style Root fill:#65d9ef,color:#1b1d1e
+    style Orch fill:#65d9ef,color:#1b1d1e
+    style Sub1 fill:#65d9ef,color:#1b1d1e
+    style Sub2 fill:#65d9ef,color:#1b1d1e
+    style Sub3 fill:#65d9ef,color:#1b1d1e
+
+    %% Business Logic Layer nodes - green
+    style Cache fill:#a7e22e,color:#1b1d1e
+    style K8s fill:#a7e22e,color:#1b1d1e
+    style Selector fill:#a7e22e,color:#1b1d1e
+    style Restarter fill:#a7e22e,color:#1b1d1e
+
+    %% External Systems nodes - purple
+    style API fill:#9e6ffe,color:#1b1d1e
+    style Argo fill:#9e6ffe,color:#1b1d1e
+    style Store fill:#9e6ffe,color:#1b1d1e
+```
+
+---
+
+## Guide Contents
+
+<div class="grid cards" markdown>
+
+-   :material-hammer-wrench:{ .lg .middle } **Framework Selection**
+
+    ---
+
+    Choose between Cobra, urfave/cli, and Kong. Configuration with Viper.
+
+    [:octicons-arrow-right-24: Framework Selection](framework-selection/index.md)
+
+-   :material-kubernetes:{ .lg .middle } **Kubernetes Integration**
+
+    ---
+
+    client-go patterns, in-cluster config, RBAC, and context handling.
+
+    [:octicons-arrow-right-24: Kubernetes Integration](kubernetes-integration/index.md)
+
+-   :material-source-branch:{ .lg .middle } **Command Architecture**
+
+    ---
+
+    Orchestrator pattern, subcommand design, and error handling.
+
+    [:octicons-arrow-right-24: Command Architecture](command-architecture/index.md)
+
+-   :material-package-variant:{ .lg .middle } **Packaging**
+
+    ---
+
+    Multi-stage builds, minimal images, Helm integration.
+
+    [:octicons-arrow-right-24: Packaging](packaging/index.md)
+
+-   :material-test-tube:{ .lg .middle } **Testing Strategies**
+
+    ---
+
+    Fake clients, integration testing, E2E in CI/CD.
+
+    [:octicons-arrow-right-24: Testing](testing/index.md)
+
+</div>
+
+---
+
+## Example Project Structure
+
+```text
+myctl/
+├── cmd/
+│   ├── root.go           # Cobra root command, global flags
+│   ├── orchestrate.go    # Main workflow orchestrator
+│   ├── check.go          # Cache check command
+│   ├── rebuild.go        # Cache rebuild command
+│   └── select.go         # Deployment selector
+├── pkg/
+│   ├── cache/            # Cache management logic
+│   │   ├── cache.go
+│   │   └── cache_test.go
+│   ├── k8s/              # Kubernetes client wrapper
+│   │   ├── client.go
+│   │   └── client_test.go
+│   ├── selector/         # Business logic
+│   │   ├── selector.go
+│   │   └── selector_test.go
+│   └── restarter/        # Deployment restart logic
+│       ├── restarter.go
+│       └── restarter_test.go
+├── Dockerfile
+├── go.mod
+├── go.sum
+└── main.go               # Entry point
+```
+
+---
+
+## Key Design Principles
+
+| Principle | Description |
+|-----------|-------------|
+| **Separation of concerns** | Commands handle CLI logic; `pkg/` handles business logic |
+| **[Testable by default](testing/index.md)** | Interfaces for external dependencies enable fake clients |
+| **[Fail fast](../error-handling/fail-fast/index.md)** | Validate configuration and connectivity before operations |
+| **[Structured output](command-architecture/io-contracts.md)** | JSON output for machine consumption, human-friendly by default |
+| **[Graceful degradation](../error-handling/graceful-degradation/index.md)** | Clear error messages with actionable context |
+
+---
+
+*Building CLIs that operators trust.*

--- a/docs/developer-guide/go-cli-architecture/kubernetes-integration/client-configuration.md
+++ b/docs/developer-guide/go-cli-architecture/kubernetes-integration/client-configuration.md
@@ -1,0 +1,196 @@
+# Client Configuration
+
+Handle both in-cluster and out-of-cluster Kubernetes configurations.
+
+!!! warning "Always Support Both Environments"
+
+    Your CLI must work on developer laptops (kubeconfig) AND inside pods (in-cluster). Test both paths or users will hit runtime failures.
+
+---
+
+## Automatic Configuration Detection
+
+```go
+package k8s
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+
+    "k8s.io/client-go/kubernetes"
+    "k8s.io/client-go/rest"
+    "k8s.io/client-go/tools/clientcmd"
+)
+
+// Client wraps the Kubernetes clientset with configuration
+type Client struct {
+    Clientset *kubernetes.Clientset
+    Config    *rest.Config
+    Namespace string
+}
+
+// NewClient creates a Kubernetes client with automatic config detection
+func NewClient(kubeconfig, namespace string) (*Client, error) {
+    config, err := getConfig(kubeconfig)
+    if err != nil {
+        return nil, fmt.Errorf("failed to get kubernetes config: %w", err)
+    }
+
+    clientset, err := kubernetes.NewForConfig(config)
+    if err != nil {
+        return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+    }
+
+    // Resolve namespace
+    ns := resolveNamespace(namespace)
+
+    return &Client{
+        Clientset: clientset,
+        Config:    config,
+        Namespace: ns,
+    }, nil
+}
+
+func getConfig(kubeconfig string) (*rest.Config, error) {
+    // Explicit kubeconfig path
+    if kubeconfig != "" {
+        return clientcmd.BuildConfigFromFlags("", kubeconfig)
+    }
+
+    // In-cluster config (running inside a pod)
+    if _, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token"); err == nil {
+        return rest.InClusterConfig()
+    }
+
+    // Default kubeconfig from environment or home directory
+    if kc := os.Getenv("KUBECONFIG"); kc != "" {
+        return clientcmd.BuildConfigFromFlags("", kc)
+    }
+
+    home, err := os.UserHomeDir()
+    if err != nil {
+        return nil, err
+    }
+
+    return clientcmd.BuildConfigFromFlags("", filepath.Join(home, ".kube", "config"))
+}
+
+func resolveNamespace(namespace string) string {
+    if namespace != "" {
+        return namespace
+    }
+
+    // Read from in-cluster namespace file
+    if ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+        return string(ns)
+    }
+
+    return "default"
+}
+```
+
+---
+
+## Context and Timeout Handling
+
+```go
+package cmd
+
+import (
+    "context"
+    "os"
+    "os/signal"
+    "syscall"
+    "time"
+
+    "github.com/spf13/cobra"
+)
+
+var timeout time.Duration
+
+func init() {
+    rootCmd.PersistentFlags().DurationVar(&timeout, "timeout", 30*time.Second, "Operation timeout")
+}
+
+func runWithContext(cmd *cobra.Command, fn func(ctx context.Context) error) error {
+    // Create context with timeout
+    ctx, cancel := context.WithTimeout(context.Background(), timeout)
+    defer cancel()
+
+    // Handle interrupt signals
+    sigCh := make(chan os.Signal, 1)
+    signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+    errCh := make(chan error, 1)
+    go func() {
+        errCh <- fn(ctx)
+    }()
+
+    select {
+    case err := <-errCh:
+        return err
+    case <-sigCh:
+        cancel()
+        return context.Canceled
+    }
+}
+
+// Usage in a command
+var checkCmd = &cobra.Command{
+    Use:   "check",
+    Short: "Check cache status",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        return runWithContext(cmd, func(ctx context.Context) error {
+            // Your operation here
+            return performCheck(ctx)
+        })
+    },
+}
+```
+
+---
+
+## Error Handling
+
+### Kubernetes-Specific Errors
+
+```go
+package k8s
+
+import (
+    "errors"
+    "fmt"
+
+    apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// HandleError provides user-friendly error messages
+func HandleError(err error, resource, name string) error {
+    if err == nil {
+        return nil
+    }
+
+    var statusErr *apierrors.StatusError
+    if errors.As(err, &statusErr) {
+        switch {
+        case apierrors.IsNotFound(err):
+            return fmt.Errorf("%s '%s' not found", resource, name)
+        case apierrors.IsForbidden(err):
+            return fmt.Errorf("permission denied: cannot access %s '%s' - check RBAC configuration", resource, name)
+        case apierrors.IsUnauthorized(err):
+            return fmt.Errorf("unauthorized: check kubeconfig or service account token")
+        case apierrors.IsTimeout(err):
+            return fmt.Errorf("timeout accessing %s '%s' - check cluster connectivity", resource, name)
+        case apierrors.IsServerTimeout(err):
+            return fmt.Errorf("server timeout - the API server may be overloaded")
+        }
+    }
+
+    return fmt.Errorf("failed to access %s '%s': %w", resource, name, err)
+}
+```
+
+---
+
+*Support all environments: explicit config, KUBECONFIG env var, in-cluster, or ~/.kube/config.*

--- a/docs/developer-guide/go-cli-architecture/kubernetes-integration/common-operations.md
+++ b/docs/developer-guide/go-cli-architecture/kubernetes-integration/common-operations.md
@@ -1,0 +1,188 @@
+# Common Operations
+
+Implement common Kubernetes operations in your CLI.
+
+---
+
+## List Deployments
+
+```go
+package k8s
+
+import (
+    "context"
+
+    appsv1 "k8s.io/api/apps/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ListDeployments returns all deployments in the configured namespace
+func (c *Client) ListDeployments(ctx context.Context) ([]appsv1.Deployment, error) {
+    list, err := c.Clientset.AppsV1().Deployments(c.Namespace).List(ctx, metav1.ListOptions{})
+    if err != nil {
+        return nil, err
+    }
+    return list.Items, nil
+}
+
+// ListDeploymentsWithLabel returns deployments matching a label selector
+func (c *Client) ListDeploymentsWithLabel(ctx context.Context, labelSelector string) ([]appsv1.Deployment, error) {
+    list, err := c.Clientset.AppsV1().Deployments(c.Namespace).List(ctx, metav1.ListOptions{
+        LabelSelector: labelSelector,
+    })
+    if err != nil {
+        return nil, err
+    }
+    return list.Items, nil
+}
+```
+
+---
+
+## Rollout Restart
+
+Trigger a rolling restart by patching the deployment's pod template annotation:
+
+```go
+package k8s
+
+import (
+    "context"
+    "fmt"
+    "time"
+
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/apimachinery/pkg/types"
+)
+
+// RestartDeployment triggers a rollout restart
+func (c *Client) RestartDeployment(ctx context.Context, name string) error {
+    // Patch the deployment with a new annotation to trigger restart
+    patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`,
+        time.Now().Format(time.RFC3339))
+
+    _, err := c.Clientset.AppsV1().Deployments(c.Namespace).Patch(
+        ctx,
+        name,
+        types.StrategicMergePatchType,
+        []byte(patch),
+        metav1.PatchOptions{},
+    )
+    return err
+}
+```
+
+---
+
+## ConfigMap Operations
+
+Store and retrieve data from ConfigMaps:
+
+```go
+package k8s
+
+import (
+    "context"
+    "fmt"
+
+    corev1 "k8s.io/api/core/v1"
+    apierrors "k8s.io/apimachinery/pkg/api/errors"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetOrCreateConfigMap retrieves or creates a ConfigMap
+func (c *Client) GetOrCreateConfigMap(ctx context.Context, name string) (*corev1.ConfigMap, error) {
+    cm, err := c.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(ctx, name, metav1.GetOptions{})
+    if err == nil {
+        return cm, nil
+    }
+
+    if !apierrors.IsNotFound(err) {
+        return nil, fmt.Errorf("failed to get configmap: %w", err)
+    }
+
+    // Create new ConfigMap
+    cm = &corev1.ConfigMap{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      name,
+            Namespace: c.Namespace,
+        },
+        Data: make(map[string]string),
+    }
+
+    return c.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+}
+
+// UpdateConfigMap updates data in a ConfigMap
+func (c *Client) UpdateConfigMap(ctx context.Context, name string, data map[string]string) error {
+    cm, err := c.GetOrCreateConfigMap(ctx, name)
+    if err != nil {
+        return err
+    }
+
+    cm.Data = data
+    _, err = c.Clientset.CoreV1().ConfigMaps(c.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+    return err
+}
+```
+
+---
+
+## Watch Resources
+
+Watch for changes to resources:
+
+```go
+package k8s
+
+import (
+    "context"
+
+    appsv1 "k8s.io/api/apps/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/apimachinery/pkg/watch"
+)
+
+// WatchDeployments watches for deployment changes
+func (c *Client) WatchDeployments(ctx context.Context) (watch.Interface, error) {
+    return c.Clientset.AppsV1().Deployments(c.Namespace).Watch(ctx, metav1.ListOptions{})
+}
+
+// Example usage
+func watchExample(ctx context.Context, client *Client) error {
+    watcher, err := client.WatchDeployments(ctx)
+    if err != nil {
+        return err
+    }
+    defer watcher.Stop()
+
+    for event := range watcher.ResultChan() {
+        deployment := event.Object.(*appsv1.Deployment)
+        switch event.Type {
+        case watch.Added:
+            fmt.Printf("Deployment added: %s\n", deployment.Name)
+        case watch.Modified:
+            fmt.Printf("Deployment modified: %s\n", deployment.Name)
+        case watch.Deleted:
+            fmt.Printf("Deployment deleted: %s\n", deployment.Name)
+        }
+    }
+    return nil
+}
+```
+
+---
+
+## Best Practices
+
+| Practice | Description |
+|----------|-------------|
+| **Use label selectors** | Filter resources server-side, not client-side |
+| **Prefer patches over updates** | Patches are safer for concurrent modifications |
+| **Use strategic merge patches** | Kubernetes-native patch format for resources |
+| **Handle not found errors** | Check `apierrors.IsNotFound(err)` before creating |
+| **Respect resource versions** | Use optimistic concurrency for updates |
+
+---
+
+*Use the Kubernetes API idiomatically: label selectors, patches, and proper error handling.*

--- a/docs/developer-guide/go-cli-architecture/kubernetes-integration/index.md
+++ b/docs/developer-guide/go-cli-architecture/kubernetes-integration/index.md
@@ -1,0 +1,74 @@
+# Kubernetes Integration
+
+Integrate your Go CLI with Kubernetes using client-go.
+
+---
+
+## Overview
+
+A well-designed Kubernetes CLI works seamlessly both on developer laptops and inside cluster pods. This section covers:
+
+- **[Client Configuration](client-configuration.md)** - Automatic config detection for all environments
+- **[RBAC Setup](rbac-setup.md)** - Service accounts and permissions
+- **[Common Operations](common-operations.md)** - List, patch, and restart resources
+
+---
+
+## Configuration Flow
+
+```mermaid
+graph TB
+    Start[Client Request] --> ExplicitKC{Explicit<br/>kubeconfig?}
+    ExplicitKC -->|Yes| UseExplicit[Use Specified Path]
+    ExplicitKC -->|No| InCluster{In-Cluster<br/>Token Exists?}
+
+    InCluster -->|Yes| UseInCluster[Use In-Cluster Config]
+    InCluster -->|No| EnvKC{KUBECONFIG<br/>Env Set?}
+
+    EnvKC -->|Yes| UseEnv[Use KUBECONFIG Path]
+    EnvKC -->|No| UseHome[Use ~/.kube/config]
+
+    UseExplicit --> CreateClient[Create Clientset]
+    UseInCluster --> CreateClient
+    UseEnv --> CreateClient
+    UseHome --> CreateClient
+
+    CreateClient --> Ready[Client Ready]
+
+    style Start fill:#65d9ef,color:#1b1d1e
+    style Ready fill:#a7e22e,color:#1b1d1e
+```
+
+---
+
+## Quick Start
+
+```go
+import "k8s.io/client-go/kubernetes"
+
+// Create a client that works everywhere
+client, err := k8s.NewClient(kubeconfig, namespace)
+if err != nil {
+    return fmt.Errorf("failed to create client: %w", err)
+}
+
+// Use the client
+deployments, err := client.ListDeployments(ctx)
+```
+
+---
+
+## Best Practices
+
+| Practice | Description |
+|----------|-------------|
+| **Use contexts everywhere** | Pass `context.Context` to all Kubernetes operations |
+| **Handle cancellation** | Respect context cancellation for clean shutdowns |
+| **Wrap errors with context** | Include resource type and name in error messages |
+| **Default to current namespace** | Match kubectl behavior for namespace resolution |
+| **Support both configs** | Always handle in-cluster and out-of-cluster scenarios |
+| **Minimal RBAC** | Request only the permissions your CLI needs |
+
+---
+
+*Build clients that work everywhere: laptop, CI runner, or pod.*

--- a/docs/developer-guide/go-cli-architecture/kubernetes-integration/rbac-setup.md
+++ b/docs/developer-guide/go-cli-architecture/kubernetes-integration/rbac-setup.md
@@ -1,0 +1,148 @@
+# RBAC Setup
+
+Configure service accounts and permissions for your CLI.
+
+---
+
+## Service Account Setup
+
+Create a service account with appropriate permissions:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: myctl
+  namespace: myctl-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: myctl-role
+rules:
+  # Read deployments across namespaces
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+
+  # Restart deployments (patch for rollout restart)
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["patch"]
+
+  # Read pods for status checks
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+
+  # ConfigMaps for cache storage
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: myctl-binding
+subjects:
+  - kind: ServiceAccount
+    name: myctl
+    namespace: myctl-system
+roleRef:
+  kind: ClusterRole
+  name: myctl-role
+  apiGroup: rbac.authorization.k8s.io
+```
+
+---
+
+## Namespace-Scoped Permissions
+
+For namespace-scoped permissions, use `Role` and `RoleBinding` instead:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: myctl-role
+  namespace: production
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: myctl-binding
+  namespace: production
+subjects:
+  - kind: ServiceAccount
+    name: myctl
+    namespace: myctl-system
+roleRef:
+  kind: Role
+  name: myctl-role
+  apiGroup: rbac.authorization.k8s.io
+```
+
+---
+
+## Permission Patterns
+
+| Operation | API Group | Resource | Verbs |
+|-----------|-----------|----------|-------|
+| List deployments | `apps` | `deployments` | `get`, `list`, `watch` |
+| Rollout restart | `apps` | `deployments` | `patch` |
+| Read pod status | `""` (core) | `pods` | `get`, `list` |
+| Manage ConfigMaps | `""` (core) | `configmaps` | `get`, `list`, `create`, `update`, `patch` |
+| Read secrets | `""` (core) | `secrets` | `get`, `list` |
+
+---
+
+## Minimal RBAC Principle
+
+!!! danger "Principle of Least Privilege"
+
+    Never use wildcard permissions (`*`). Security teams will reject your deployment, and over-permissioned service accounts are a breach waiting to happen.
+
+Only request permissions your CLI actually needs:
+
+```yaml
+# Bad: Too broad
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+
+# Good: Specific permissions
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch"]
+```
+
+---
+
+## Debugging RBAC Issues
+
+Check if your service account has the required permissions:
+
+```bash
+# Can I list deployments?
+kubectl auth can-i list deployments --as=system:serviceaccount:myctl-system:myctl
+
+# Can I patch deployments in production namespace?
+kubectl auth can-i patch deployments -n production \
+    --as=system:serviceaccount:myctl-system:myctl
+```
+
+---
+
+*Minimal RBAC: only grant what your CLI needs to function.*

--- a/docs/developer-guide/go-cli-architecture/packaging/container-builds.md
+++ b/docs/developer-guide/go-cli-architecture/packaging/container-builds.md
@@ -1,0 +1,199 @@
+# Container Builds
+
+Create minimal, secure container images with multi-stage builds.
+
+---
+
+## Standard Pattern
+
+```dockerfile
+# Build stage
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /app
+
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Build binary
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-w -s -X main.version=${VERSION:-dev}" \
+    -o /myctl \
+    ./main.go
+
+# Runtime stage
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /myctl /myctl
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/myctl"]
+```
+
+---
+
+## Distroless Benefits
+
+!!! danger "Security First"
+
+    Never use `latest` tags in production. Pin to specific versions and scan images for vulnerabilities in CI.
+
+Distroless is preferred for security:
+
+- No shell (reduces attack surface)
+- No package manager
+- Non-root user by default
+- Automatic security updates via base image
+
+```dockerfile
+# Use nonroot variant for security
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# Or debug variant for troubleshooting (includes shell)
+FROM gcr.io/distroless/static-debian12:debug-nonroot
+```
+
+---
+
+## Version Injection
+
+### Build-Time Variables
+
+```go
+// main.go
+package main
+
+import (
+    "myctl/cmd"
+)
+
+// Set via ldflags at build time
+var (
+    version = "dev"
+    commit  = "unknown"
+    date    = "unknown"
+)
+
+func main() {
+    cmd.SetVersionInfo(version, commit, date)
+    cmd.Execute()
+}
+```
+
+```go
+// cmd/version.go
+package cmd
+
+import (
+    "fmt"
+    "runtime"
+
+    "github.com/spf13/cobra"
+)
+
+var (
+    Version string
+    Commit  string
+    Date    string
+)
+
+func SetVersionInfo(version, commit, date string) {
+    Version = version
+    Commit = commit
+    Date = date
+}
+
+var versionCmd = &cobra.Command{
+    Use:   "version",
+    Short: "Print version information",
+    Run: func(cmd *cobra.Command, args []string) {
+        fmt.Printf("Version:    %s\n", Version)
+        fmt.Printf("Commit:     %s\n", Commit)
+        fmt.Printf("Built:      %s\n", Date)
+        fmt.Printf("Go version: %s\n", runtime.Version())
+        fmt.Printf("OS/Arch:    %s/%s\n", runtime.GOOS, runtime.GOARCH)
+    },
+}
+
+func init() {
+    rootCmd.AddCommand(versionCmd)
+}
+```
+
+### Build Script
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+VERSION="${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo 'dev')}"
+COMMIT="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')}"
+DATE="${DATE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+
+go build \
+    -ldflags="-w -s \
+        -X main.version=${VERSION} \
+        -X main.commit=${COMMIT} \
+        -X main.date=${DATE}" \
+    -o myctl \
+    ./main.go
+```
+
+---
+
+## Multi-Architecture Builds
+
+### Dockerfile for Multi-Arch
+
+```dockerfile
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -ldflags="-w -s -X main.version=${VERSION}" \
+    -o /myctl \
+    ./main.go
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /myctl /myctl
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/myctl"]
+```
+
+---
+
+## Security Context
+
+When deploying, use a secure pod security context:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+```
+
+---
+
+*Small image + non-root + read-only = secure container.*

--- a/docs/developer-guide/go-cli-architecture/packaging/helm-charts.md
+++ b/docs/developer-guide/go-cli-architecture/packaging/helm-charts.md
@@ -1,0 +1,197 @@
+# Helm Charts
+
+Deploy your CLI with Helm for Kubernetes environments.
+
+---
+
+## Chart Structure
+
+```text
+charts/myctl/
+├── Chart.yaml
+├── values.yaml
+├── templates/
+│   ├── deployment.yaml
+│   ├── serviceaccount.yaml
+│   ├── role.yaml
+│   └── rolebinding.yaml
+└── .helmignore
+```
+
+---
+
+## Chart.yaml
+
+```yaml
+apiVersion: v2
+name: myctl
+description: Kubernetes orchestration CLI
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+```
+
+---
+
+## values.yaml
+
+```yaml
+image:
+  repository: ghcr.io/myorg/myctl
+  tag: ""  # Defaults to appVersion
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: ""  # Generated if not specified
+
+rbac:
+  create: true
+  clusterWide: false  # Use Role vs ClusterRole
+
+namespace: default
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+config:
+  cacheTTL: 300
+  verbose: false
+```
+
+---
+
+## Deployment Template
+
+Use `Job` resources for one-shot CLI operations:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "myctl.fullname" . }}
+  labels:
+    {{- include "myctl.labels" . | nindent 4 }}
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ include "myctl.serviceAccountName" . }}
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - orchestrate
+            - --namespace={{ .Values.namespace }}
+            {{- if .Values.config.verbose }}
+            - --verbose
+            {{- end }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+  backoffLimit: 3
+```
+
+---
+
+## ServiceAccount Template
+
+```yaml
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "myctl.serviceAccountName" . }}
+  labels:
+    {{- include "myctl.labels" . | nindent 4 }}
+{{- end }}
+```
+
+---
+
+## RBAC Templates
+
+### Role (namespace-scoped)
+
+```yaml
+{{- if .Values.rbac.create -}}
+{{- if not .Values.rbac.clusterWide }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "myctl.fullname" . }}
+  labels:
+    {{- include "myctl.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create", "update", "patch"]
+{{- end }}
+{{- end }}
+```
+
+### RoleBinding
+
+```yaml
+{{- if .Values.rbac.create -}}
+{{- if not .Values.rbac.clusterWide }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "myctl.fullname" . }}
+  labels:
+    {{- include "myctl.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "myctl.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "myctl.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}
+```
+
+---
+
+## Installation
+
+```bash
+# Install from local chart
+helm install myctl ./charts/myctl -n myctl-system --create-namespace
+
+# Install with custom values
+helm install myctl ./charts/myctl \
+  --set namespace=production \
+  --set config.verbose=true
+
+# Upgrade
+helm upgrade myctl ./charts/myctl --reuse-values
+```
+
+---
+
+*Helm charts make your CLI deployable with standard Kubernetes tooling.*

--- a/docs/developer-guide/go-cli-architecture/packaging/index.md
+++ b/docs/developer-guide/go-cli-architecture/packaging/index.md
@@ -1,0 +1,65 @@
+# Packaging
+
+Build minimal, secure container images for your Go CLI.
+
+---
+
+## Overview
+
+Packaging a Go CLI for Kubernetes involves creating small, secure container images that can run anywhere. This section covers:
+
+- **[Container Builds](container-builds.md)** - Multi-stage Dockerfiles with distroless
+- **[Helm Charts](helm-charts.md)** - Deploy your CLI with Helm
+- **[Release Automation](release-automation.md)** - Multi-arch builds and GoReleaser
+
+---
+
+## Build Flow
+
+```mermaid
+graph LR
+    subgraph Build["Build Stage (~800MB)"]
+        Go[golang:1.23-alpine]
+        Deps[Download Dependencies]
+        Compile[Compile Binary]
+    end
+
+    subgraph Runtime["Runtime Stage (~2MB)"]
+        Distroless[distroless/static]
+        Binary[Static Binary]
+    end
+
+    Go --> Deps --> Compile --> Binary
+    Distroless --> Binary
+
+    style Build fill:#65d9ef,color:#1b1d1e
+    style Runtime fill:#a7e22e,color:#1b1d1e
+```
+
+---
+
+## Base Image Selection
+
+| Image | Size | Use Case |
+|-------|------|----------|
+| `gcr.io/distroless/static` | ~2MB | Pure Go, no CGO |
+| `gcr.io/distroless/base` | ~20MB | Needs libc |
+| `alpine:3.19` | ~7MB | Need shell/debugging |
+| `scratch` | 0MB | Maximum minimal (no TLS certs) |
+
+---
+
+## Best Practices
+
+| Practice | Description |
+|----------|-------------|
+| **Static binaries** | Use `CGO_ENABLED=0` for portable builds |
+| **Non-root user** | Always run as non-root in containers |
+| **Read-only filesystem** | Set `readOnlyRootFilesystem: true` |
+| **Drop capabilities** | Remove all capabilities with `drop: ALL` |
+| **Version in binary** | Inject version at build time |
+| **Multi-arch support** | Build for both amd64 and arm64 |
+
+---
+
+*Ship binaries that run anywhere Kubernetes runs.*

--- a/docs/developer-guide/go-cli-architecture/packaging/release-automation.md
+++ b/docs/developer-guide/go-cli-architecture/packaging/release-automation.md
@@ -1,0 +1,224 @@
+# Release Automation
+
+Automate multi-architecture builds and releases with GitHub Actions and GoReleaser.
+
+---
+
+## GitHub Actions Workflow
+
+```yaml
+name: Build and Push
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+```
+
+---
+
+## GoReleaser Configuration
+
+For automated binary releases, use [GoReleaser](https://goreleaser.com/):
+
+```yaml
+# .goreleaser.yaml
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: myctl
+    binary: myctl
+    main: ./main.go
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: myctl
+    formats:
+      - tar.gz
+      - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+
+dockers:
+  - image_templates:
+      - "ghcr.io/myorg/myctl:{{ .Version }}-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+    dockerfile: Dockerfile
+
+  - image_templates:
+      - "ghcr.io/myorg/myctl:{{ .Version }}-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    goarch: arm64
+    dockerfile: Dockerfile
+
+docker_manifests:
+  - name_template: "ghcr.io/myorg/myctl:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/myorg/myctl:{{ .Version }}-amd64"
+      - "ghcr.io/myorg/myctl:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/myorg/myctl:latest"
+    image_templates:
+      - "ghcr.io/myorg/myctl:{{ .Version }}-amd64"
+      - "ghcr.io/myorg/myctl:{{ .Version }}-arm64"
+```
+
+---
+
+## Release Workflow with GoReleaser
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+---
+
+## Makefile Integration
+
+```makefile
+.PHONY: release snapshot
+
+VERSION ?= $(shell git describe --tags --always --dirty)
+
+release:
+    goreleaser release --clean
+
+snapshot:
+    goreleaser release --snapshot --clean
+
+docker-build:
+    docker build --build-arg VERSION=$(VERSION) -t myctl:$(VERSION) .
+
+docker-push:
+    docker push ghcr.io/myorg/myctl:$(VERSION)
+```
+
+---
+
+*Automate releases: one tag push creates binaries, images, and changelogs.*

--- a/docs/developer-guide/go-cli-architecture/testing/e2e-testing.md
+++ b/docs/developer-guide/go-cli-architecture/testing/e2e-testing.md
@@ -1,0 +1,185 @@
+# E2E Testing
+
+Test full workflows in real clusters with CI/CD integration.
+
+---
+
+## GitHub Actions Workflow
+
+```yaml
+name: E2E Tests
+
+on: [pull_request]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - uses: helm/kind-action@v1
+        with:
+          cluster_name: test-cluster
+
+      - name: Build CLI
+        run: go build -o myctl ./main.go
+
+      - name: Run E2E tests
+        run: |
+          kubectl create namespace e2e-test
+          kubectl -n e2e-test apply -f test/fixtures/
+          ./myctl orchestrate --namespace e2e-test --dry-run
+```
+
+---
+
+## E2E Test Script
+
+!!! warning "Always Clean Up"
+
+    Use `trap cleanup EXIT` to ensure test namespaces are deleted even when tests fail. Orphaned resources waste cluster resources and can cause conflicts in later runs.
+
+```bash
+#!/bin/bash
+# test/e2e/run.sh
+set -euo pipefail
+
+NAMESPACE="e2e-test-$(date +%s)"
+
+cleanup() {
+    kubectl delete namespace "$NAMESPACE" --ignore-not-found
+}
+trap cleanup EXIT
+
+echo "Creating test namespace: $NAMESPACE"
+kubectl create namespace "$NAMESPACE"
+
+echo "Deploying test fixtures..."
+kubectl -n "$NAMESPACE" apply -f test/fixtures/
+
+echo "Waiting for deployments..."
+kubectl -n "$NAMESPACE" wait --for=condition=available deployment --all --timeout=60s
+
+echo "Running orchestrate command..."
+./myctl orchestrate --namespace "$NAMESPACE"
+
+echo "Verifying results..."
+RESTARTS=$(kubectl -n "$NAMESPACE" get pods -o jsonpath='{.items[*].status.containerStatuses[*].restartCount}')
+if [[ "$RESTARTS" != "0 0 0" ]]; then
+    echo "ERROR: Unexpected restart counts: $RESTARTS"
+    exit 1
+fi
+
+echo "E2E tests passed!"
+```
+
+---
+
+## Test Fixtures
+
+```yaml
+# test/fixtures/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+  labels:
+    app: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+        - name: main
+          image: nginx:alpine
+          resources:
+            limits:
+              cpu: 50m
+              memory: 64Mi
+```
+
+---
+
+## Matrix Testing
+
+Test across multiple Kubernetes versions:
+
+```yaml
+name: E2E Matrix
+
+on: [pull_request]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s-version:
+          - v1.28.0
+          - v1.29.0
+          - v1.30.0
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: helm/kind-action@v1
+        with:
+          node_image: kindest/node:${{ matrix.k8s-version }}
+          cluster_name: test-cluster
+
+      - name: Build and Test
+        run: |
+          go build -o myctl ./main.go
+          ./test/e2e/run.sh
+```
+
+---
+
+## Smoke Tests in Production
+
+For production verification without risk:
+
+```bash
+#!/bin/bash
+# Smoke test - read-only operations only
+set -euo pipefail
+
+echo "Running smoke tests..."
+
+# Check version
+./myctl version
+
+# Check without making changes
+./myctl check --json
+
+# List without restart
+./myctl select --output json
+
+echo "Smoke tests passed!"
+```
+
+---
+
+## Best Practices
+
+| Practice | Description |
+|----------|-------------|
+| **Isolated namespaces** | Create unique namespaces per test run |
+| **Cleanup on exit** | Always clean up, even on failure |
+| **Timeouts** | Set reasonable timeouts for resource waits |
+| **Dry run first** | Test with `--dry-run` before real operations |
+| **Matrix testing** | Test across multiple Kubernetes versions |
+
+---
+
+*E2E tests catch workflow bugs that integration tests miss.*

--- a/docs/developer-guide/go-cli-architecture/testing/index.md
+++ b/docs/developer-guide/go-cli-architecture/testing/index.md
@@ -1,0 +1,95 @@
+# Testing Strategies
+
+Build confidence in your CLI with comprehensive testing at every level.
+
+---
+
+## Overview
+
+A well-tested CLI uses different testing strategies at different levels. This section covers:
+
+- **[Unit Testing](unit-testing.md)** - Fake clients and interface-based design
+- **[Integration Testing](integration-testing.md)** - envtest and real API servers
+- **[E2E Testing](e2e-testing.md)** - Full workflow tests in CI/CD
+
+---
+
+## Testing Pyramid
+
+```mermaid
+graph TB
+    subgraph E2E["E2E Tests (Few)"]
+        E2ETests[Full workflow in<br/>real cluster]
+    end
+
+    subgraph Integration["Integration Tests (Some)"]
+        IntTests[Real API server<br/>kind/envtest]
+    end
+
+    subgraph Unit["Unit Tests (Many)"]
+        UnitTests[Fake clients<br/>Mock interfaces]
+    end
+
+    E2ETests --> IntTests --> UnitTests
+
+    style E2E fill:#9e6ffe,color:#1b1d1e
+    style Integration fill:#65d9ef,color:#1b1d1e
+    style Unit fill:#a7e22e,color:#1b1d1e
+```
+
+---
+
+## Test Organization
+
+```text
+myctl/
+├── cmd/
+│   ├── check.go
+│   └── check_test.go        # Command tests
+├── pkg/
+│   ├── k8s/
+│   │   ├── client.go
+│   │   ├── client_test.go   # Unit tests with fakes
+│   │   └── fake_client.go   # Test doubles
+│   └── selector/
+│       ├── selector.go
+│       └── selector_test.go
+└── test/
+    ├── e2e/                  # E2E tests
+    └── fixtures/             # Test resources
+```
+
+---
+
+## Makefile Targets
+
+```makefile
+.PHONY: test test-unit test-integration test-e2e
+
+test: test-unit
+
+test-unit:
+    go test -v -race ./...
+
+test-integration:
+    go test -v -tags=integration ./pkg/...
+
+test-e2e:
+    ./test/e2e/run.sh
+```
+
+---
+
+## Best Practices
+
+| Practice | Description |
+|----------|-------------|
+| **Interface first** | Design for testability with interfaces |
+| **Table-driven tests** | Cover edge cases systematically |
+| **Parallel tests** | Use `t.Parallel()` where safe |
+| **Build tags** | Separate integration tests with `//go:build integration` |
+| **Clean up** | Always clean up test resources |
+
+---
+
+*Test at the right level. Unit tests catch logic bugs. Integration tests catch API issues. E2E tests catch workflow bugs.*

--- a/docs/developer-guide/go-cli-architecture/testing/integration-testing.md
+++ b/docs/developer-guide/go-cli-architecture/testing/integration-testing.md
@@ -1,0 +1,216 @@
+# Integration Testing
+
+Test against real Kubernetes API servers with envtest.
+
+---
+
+## Setup with envtest
+
+Use `sigs.k8s.io/controller-runtime/pkg/envtest` for testing against a real API server:
+
+```go
+//go:build integration
+
+package k8s
+
+import (
+    "context"
+    "os"
+    "testing"
+
+    "k8s.io/client-go/kubernetes"
+    "sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+    testEnv   *envtest.Environment
+    clientset *kubernetes.Clientset
+)
+
+func TestMain(m *testing.M) {
+    testEnv = &envtest.Environment{}
+
+    cfg, err := testEnv.Start()
+    if err != nil {
+        panic(err)
+    }
+
+    clientset, err = kubernetes.NewForConfig(cfg)
+    if err != nil {
+        panic(err)
+    }
+
+    code := m.Run()
+
+    if err := testEnv.Stop(); err != nil {
+        panic(err)
+    }
+
+    os.Exit(code)
+}
+
+func TestListDeployments(t *testing.T) {
+    ctx := context.Background()
+
+    // Create test deployment
+    deployment := createTestDeployment("test-app")
+    _, err := clientset.AppsV1().Deployments("default").Create(ctx, deployment, metav1.CreateOptions{})
+    if err != nil {
+        t.Fatalf("failed to create deployment: %v", err)
+    }
+
+    // Test listing
+    client := &Client{Clientset: clientset, Namespace: "default"}
+    deployments, err := client.ListDeployments(ctx)
+    if err != nil {
+        t.Fatalf("failed to list deployments: %v", err)
+    }
+
+    if len(deployments) != 1 {
+        t.Errorf("expected 1 deployment, got %d", len(deployments))
+    }
+}
+```
+
+---
+
+## Build Tags
+
+Run integration tests with build tags:
+
+```bash
+# Run only unit tests (default)
+go test -v ./...
+
+# Run integration tests
+go test -v -tags=integration ./pkg/...
+
+# Run all tests
+go test -v -tags=integration ./...
+```
+
+---
+
+## Test Fixtures
+
+Create reusable test helpers:
+
+```go
+//go:build integration
+
+package k8s
+
+import (
+    appsv1 "k8s.io/api/apps/v1"
+    corev1 "k8s.io/api/core/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createTestDeployment(name string) *appsv1.Deployment {
+    replicas := int32(1)
+    return &appsv1.Deployment{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      name,
+            Namespace: "default",
+            Labels: map[string]string{
+                "app": name,
+            },
+        },
+        Spec: appsv1.DeploymentSpec{
+            Replicas: &replicas,
+            Selector: &metav1.LabelSelector{
+                MatchLabels: map[string]string{
+                    "app": name,
+                },
+            },
+            Template: corev1.PodTemplateSpec{
+                ObjectMeta: metav1.ObjectMeta{
+                    Labels: map[string]string{
+                        "app": name,
+                    },
+                },
+                Spec: corev1.PodSpec{
+                    Containers: []corev1.Container{
+                        {
+                            Name:  "main",
+                            Image: "nginx:latest",
+                        },
+                    },
+                },
+            },
+        },
+    }
+}
+
+func createTestNamespace(name string) *corev1.Namespace {
+    return &corev1.Namespace{
+        ObjectMeta: metav1.ObjectMeta{
+            Name: name,
+        },
+    }
+}
+```
+
+---
+
+## Cleanup Patterns
+
+Always clean up test resources:
+
+```go
+func TestWithCleanup(t *testing.T) {
+    ctx := context.Background()
+
+    // Create namespace for test isolation
+    ns := createTestNamespace("test-" + randomSuffix())
+    _, err := clientset.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+    if err != nil {
+        t.Fatalf("failed to create namespace: %v", err)
+    }
+
+    // Ensure cleanup
+    t.Cleanup(func() {
+        clientset.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
+    })
+
+    // Run tests in isolated namespace
+    // ...
+}
+```
+
+---
+
+## Testing with kind
+
+For more realistic integration tests, use kind:
+
+```go
+//go:build integration
+
+package e2e
+
+import (
+    "os/exec"
+    "testing"
+)
+
+func TestMain(m *testing.M) {
+    // Create kind cluster
+    cmd := exec.Command("kind", "create", "cluster", "--name", "test-cluster")
+    if err := cmd.Run(); err != nil {
+        panic(err)
+    }
+
+    code := m.Run()
+
+    // Delete kind cluster
+    cmd = exec.Command("kind", "delete", "cluster", "--name", "test-cluster")
+    cmd.Run()
+
+    os.Exit(code)
+}
+```
+
+---
+
+*Integration tests catch API contract issues that unit tests miss.*

--- a/docs/developer-guide/go-cli-architecture/testing/unit-testing.md
+++ b/docs/developer-guide/go-cli-architecture/testing/unit-testing.md
@@ -1,0 +1,215 @@
+# Unit Testing
+
+Use fake clients and interface-based design for fast, reliable unit tests.
+
+!!! info "Why Fakes Over Mocks"
+
+    Fakes are simpler to maintain than mocks. They implement the same interface and let you verify behavior through state inspection rather than call verification.
+
+---
+
+## Interface-Based Design
+
+Define interfaces for testability:
+
+```go
+// pkg/k8s/interfaces.go
+package k8s
+
+import (
+    "context"
+
+    appsv1 "k8s.io/api/apps/v1"
+)
+
+// DeploymentClient defines operations on deployments
+type DeploymentClient interface {
+    List(ctx context.Context, namespace string) ([]appsv1.Deployment, error)
+    Restart(ctx context.Context, namespace, name string) error
+}
+```
+
+---
+
+## Fake Implementation
+
+```go
+// pkg/k8s/fake_client.go
+package k8s
+
+import (
+    "context"
+    "fmt"
+
+    appsv1 "k8s.io/api/apps/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type FakeDeploymentClient struct {
+    Deployments map[string]*appsv1.Deployment
+    RestartLog  []string
+    ListError   error
+    RestartError error
+}
+
+func NewFakeDeploymentClient() *FakeDeploymentClient {
+    return &FakeDeploymentClient{
+        Deployments: make(map[string]*appsv1.Deployment),
+        RestartLog:  []string{},
+    }
+}
+
+func (f *FakeDeploymentClient) AddDeployment(namespace, name string, labels map[string]string) {
+    key := fmt.Sprintf("%s/%s", namespace, name)
+    f.Deployments[key] = &appsv1.Deployment{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      name,
+            Namespace: namespace,
+            Labels:    labels,
+        },
+    }
+}
+
+func (f *FakeDeploymentClient) List(ctx context.Context, namespace string) ([]appsv1.Deployment, error) {
+    if f.ListError != nil {
+        return nil, f.ListError
+    }
+    // Return matching deployments
+    var result []appsv1.Deployment
+    for _, d := range f.Deployments {
+        if d.Namespace == namespace {
+            result = append(result, *d)
+        }
+    }
+    return result, nil
+}
+
+func (f *FakeDeploymentClient) Restart(ctx context.Context, namespace, name string) error {
+    if f.RestartError != nil {
+        return f.RestartError
+    }
+    f.RestartLog = append(f.RestartLog, fmt.Sprintf("%s/%s", namespace, name))
+    return nil
+}
+```
+
+---
+
+## Table-Driven Tests
+
+```go
+func TestSelectDeployments(t *testing.T) {
+    tests := []struct {
+        name      string
+        setup     func(*k8s.FakeDeploymentClient)
+        wantCount int
+        wantErr   bool
+    }{
+        {
+            name: "selects matching deployments",
+            setup: func(fc *k8s.FakeDeploymentClient) {
+                fc.AddDeployment("default", "app-1", map[string]string{"app": "myapp"})
+                fc.AddDeployment("default", "app-2", map[string]string{"app": "myapp"})
+            },
+            wantCount: 2,
+        },
+        {
+            name: "returns empty for no matches",
+            setup: func(fc *k8s.FakeDeploymentClient) {
+                fc.AddDeployment("other", "app-1", map[string]string{"app": "myapp"})
+            },
+            wantCount: 0,
+        },
+        {
+            name: "handles list error",
+            setup: func(fc *k8s.FakeDeploymentClient) {
+                fc.ListError = fmt.Errorf("connection refused")
+            },
+            wantErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            fc := k8s.NewFakeDeploymentClient()
+            tt.setup(fc)
+
+            got, err := selectDeployments(context.Background(), fc, "default")
+
+            if (err != nil) != tt.wantErr {
+                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+            }
+            if len(got) != tt.wantCount {
+                t.Errorf("got %d deployments, want %d", len(got), tt.wantCount)
+            }
+        })
+    }
+}
+```
+
+---
+
+## Testing Commands
+
+```go
+package cmd
+
+import (
+    "bytes"
+    "strings"
+    "testing"
+
+    "github.com/spf13/cobra"
+)
+
+func executeCommand(root *cobra.Command, args ...string) (string, error) {
+    buf := new(bytes.Buffer)
+    root.SetOut(buf)
+    root.SetErr(buf)
+    root.SetArgs(args)
+    err := root.Execute()
+    return buf.String(), err
+}
+
+func TestCheckCommand(t *testing.T) {
+    output, err := executeCommand(rootCmd, "check", "--json")
+    if err != nil {
+        t.Errorf("unexpected error: %v", err)
+    }
+    if !strings.Contains(output, `"valid"`) {
+        t.Errorf("expected JSON output with valid field")
+    }
+}
+
+func TestVersionCommand(t *testing.T) {
+    output, err := executeCommand(rootCmd, "version")
+    if err != nil {
+        t.Errorf("unexpected error: %v", err)
+    }
+    if !strings.Contains(output, "Version:") {
+        t.Errorf("expected version output, got: %s", output)
+    }
+}
+```
+
+---
+
+## Parallel Tests
+
+```go
+func TestDeploymentOperations(t *testing.T) {
+    t.Run("list", func(t *testing.T) {
+        t.Parallel()
+        // test list operation
+    })
+
+    t.Run("restart", func(t *testing.T) {
+        t.Parallel()
+        // test restart operation
+    })
+}
+```
+
+---
+
+*Fast unit tests with fakes catch logic bugs early.*

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -50,6 +50,14 @@ This guide covers patterns and architecture for reliable automation at scale. Wh
 
     [:octicons-arrow-right-24: Workflow Architecture](workflow-architecture/index.md)
 
+-   :material-language-go:{ .lg .middle } **Go CLI Architecture**
+
+    ---
+
+    Build Kubernetes-native orchestration CLIs.
+
+    [:octicons-arrow-right-24: Go CLI Architecture](go-cli-architecture/index.md)
+
 </div>
 
 ---
@@ -65,6 +73,11 @@ This guide covers patterns and architecture for reliable automation at scale. Wh
 | Efficiency | [Work Avoidance](efficiency-patterns/work-avoidance/index.md) | Skip unnecessary operations |
 | Architecture | [Three-Stage Design](workflow-architecture/three-stage-design.md) | Discovery, execution, summary |
 | Architecture | [Matrix Distribution](workflow-architecture/matrix-distribution/index.md) | Parallel multi-target operations |
+| Go CLI | [Framework Selection](go-cli-architecture/framework-selection/index.md) | Choose CLI frameworks and config |
+| Go CLI | [Kubernetes Integration](go-cli-architecture/kubernetes-integration/index.md) | client-go patterns and RBAC |
+| Go CLI | [Command Architecture](go-cli-architecture/command-architecture/index.md) | Orchestrator and subcommand design |
+| Go CLI | [Packaging](go-cli-architecture/packaging/index.md) | Container builds and Helm charts |
+| Go CLI | [Testing](go-cli-architecture/testing/index.md) | Unit, integration, and E2E testing |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,6 +226,32 @@ nav:
               - Conditional Distribution: developer-guide/workflow-architecture/matrix-distribution/conditional-distribution.md
               - Template Rendering: developer-guide/workflow-architecture/matrix-distribution/template-rendering.md
               - Anti-Patterns: developer-guide/workflow-architecture/matrix-distribution/anti-patterns.md
+      - Go CLI Architecture:
+          - developer-guide/go-cli-architecture/index.md
+          - Framework Selection:
+              - developer-guide/go-cli-architecture/framework-selection/index.md
+              - CLI Frameworks: developer-guide/go-cli-architecture/framework-selection/cli-frameworks.md
+              - Viper Configuration: developer-guide/go-cli-architecture/framework-selection/viper-configuration.md
+          - Kubernetes Integration:
+              - developer-guide/go-cli-architecture/kubernetes-integration/index.md
+              - Client Configuration: developer-guide/go-cli-architecture/kubernetes-integration/client-configuration.md
+              - RBAC Setup: developer-guide/go-cli-architecture/kubernetes-integration/rbac-setup.md
+              - Common Operations: developer-guide/go-cli-architecture/kubernetes-integration/common-operations.md
+          - Command Architecture:
+              - developer-guide/go-cli-architecture/command-architecture/index.md
+              - Orchestrator Pattern: developer-guide/go-cli-architecture/command-architecture/orchestrator-pattern.md
+              - Subcommand Design: developer-guide/go-cli-architecture/command-architecture/subcommand-design.md
+              - I/O Contracts: developer-guide/go-cli-architecture/command-architecture/io-contracts.md
+          - Packaging:
+              - developer-guide/go-cli-architecture/packaging/index.md
+              - Container Builds: developer-guide/go-cli-architecture/packaging/container-builds.md
+              - Helm Charts: developer-guide/go-cli-architecture/packaging/helm-charts.md
+              - Release Automation: developer-guide/go-cli-architecture/packaging/release-automation.md
+          - Testing:
+              - developer-guide/go-cli-architecture/testing/index.md
+              - Unit Testing: developer-guide/go-cli-architecture/testing/unit-testing.md
+              - Integration Testing: developer-guide/go-cli-architecture/testing/integration-testing.md
+              - E2E Testing: developer-guide/go-cli-architecture/testing/e2e-testing.md
   - Roadmap: roadmap.md
   - About:
       - about/index.md


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for building Kubernetes-native CLIs in Go
- Framework selection guide (Cobra, urfave/cli, Kong)
- Kubernetes client-go integration patterns
- Command architecture with orchestrator pattern
- Multi-stage Docker builds and Helm charts
- Testing strategies (unit, integration, E2E)

## Test plan
- [x] All pre-commit hooks pass
- [x] MkDocs build succeeds
- [ ] Review rendered documentation

Closes #42