### PR TITLE
fix: exclude bot PRs from Claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip bot PRs (Renovate, release-please, Dependabot, etc.)
+    if: |
+      github.event.pull_request.user.type != 'Bot' &&
+      !startsWith(github.head_ref, 'renovate/') &&
+      !startsWith(github.head_ref, 'release-please--')
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Skip Claude code review for automated PRs from bots.

## Changes

Adds conditional to `claude-code-review.yml` to skip:
- Bot accounts (`user.type != 'Bot'`)
- Renovate branches (`renovate/*`)
- Release-please branches (`release-please--*`)

## Why

- Prevents unnecessary API calls on dependency updates
- Avoids failed workflow runs (bots don't need code review)
- Saves Claude Max subscription credits

## Test plan

- [ ] Verify human PRs still trigger code review
- [ ] Verify Renovate PRs are skipped
- [ ] Verify release-please PRs are skipped