### PR TITLE
fix: grant write permissions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write      # Push branches, create commits
+      pull-requests: write # Create PRs
+      issues: write        # Comment on issues
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read        # Read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Fix permissions for the Claude Code workflow so it can push branches and create PRs.

## Problem

Claude successfully created the blog post for issue #120 but couldn't push:
> "The changes have been committed locally but I encountered a permissions issue when attempting to push"

## Changes

Upgraded permissions in `claude.yml`:
- `contents: read` → `contents: write` (push branches)
- `pull-requests: read` → `pull-requests: write` (create PRs)
- `issues: read` → `issues: write` (comment on issues)

## Test plan

- [ ] Trigger Claude on an issue with `@claude`
- [ ] Verify Claude can push branches
- [ ] Verify Claude can create PRs