### PR TITLE
fix: make docs commits visible in CHANGELOG for documentation repo

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,11 +4,11 @@
   "tag-separator": "-",
   "always-update": true,
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "feat", "section": "New Content" },
+    { "type": "docs", "section": "Documentation Updates" },
+    { "type": "fix", "section": "Content Fixes" },
+    { "type": "refactor", "section": "Content Refactoring" },
     { "type": "perf", "section": "Performance" },
-    { "type": "refactor", "section": "Code Refactoring" },
-    { "type": "docs", "section": "Documentation", "hidden": true },
     { "type": "chore", "section": "Maintenance" },
     { "type": "test", "section": "Tests", "hidden": true },
     { "type": "ci", "section": "CI/CD", "hidden": true }


### PR DESCRIPTION
## Summary

Fixes release-please configuration to make documentation changes visible in CHANGELOG.md, which makes sense for a documentation-only repository.

## Problem

The current `release-please-config.json` had docs commits marked as `"hidden": true`:

```json
{ "type": "docs", "section": "Documentation", "hidden": true }
```

This caused CHANGELOG.md to **omit all documentation changes**, which makes no sense for a documentation-only repository where:
- Every meaningful change IS documentation
- The CHANGELOG should show what content was added/updated
- Hiding docs commits means the CHANGELOG would be mostly empty

## Solution

Updated `release-please-config.json` to:

1. **Remove "hidden: true"** from docs commits
2. **Rename sections** for docs-repo context:
   - `feat` → "New Content"
   - `docs` → "Documentation Updates"
   - `fix` → "Content Fixes"
   - `refactor` → "Content Refactoring"
3. **Reorder sections** to prioritize content types
4. **Keep test/ci hidden** (infrastructure, not user-facing)

## Changes

```diff
  "changelog-sections": [
-   { "type": "feat", "section": "Features" },
-   { "type": "fix", "section": "Bug Fixes" },
+   { "type": "feat", "section": "New Content" },
+   { "type": "docs", "section": "Documentation Updates" },
+   { "type": "fix", "section": "Content Fixes" },
+   { "type": "refactor", "section": "Content Refactoring" },
    { "type": "perf", "section": "Performance" },
-   { "type": "refactor", "section": "Code Refactoring" },
-   { "type": "docs", "section": "Documentation", "hidden": true },
    { "type": "chore", "section": "Maintenance" },
    { "type": "test", "section": "Tests", "hidden": true },
    { "type": "ci", "section": "CI/CD", "hidden": true }
  ],
```

## Impact

**Before**: CHANGELOG.md would be mostly empty, hiding all docs commits
**After**: CHANGELOG.md will show documentation changes, making it useful for readers

Future releases will now properly document:
- New blog posts
- New guides and tutorials
- Content updates and fixes
- Documentation refactoring

## Testing

- [x] Commit created with proper formatting
- [x] Pre-commit hooks passed
- [x] Configuration file is valid JSON
- [x] Release-please schema is valid

## Related

This fixes the issue where PR #136 (with 7 blog posts and comprehensive SDLC guides) would not appear in the CHANGELOG despite being a significant content update.