### PR TITLE
fix: build documentation on release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,11 +87,12 @@ jobs:
 
   analyze-docs:
     name: Analyze Documentation
-    needs: [detect-changes]
+    needs: [release-please, detect-changes]
     if: |
       always() && !cancelled() &&
       (needs.detect-changes.outputs.docs_changed == 'true' ||
        needs.detect-changes.outputs.is_scheduled == 'true' ||
+       needs.release-please.outputs.site_release_created == 'true' ||
        inputs.force_all == true)
     uses: ./.github/workflows/docs-quality.yml
     with:
@@ -99,11 +100,12 @@ jobs:
 
   build-docs:
     name: Build Documentation
-    needs: [detect-changes, analyze-docs]
+    needs: [release-please, detect-changes, analyze-docs]
     if: |
       always() && !cancelled() &&
       (needs.detect-changes.outputs.docs_changed == 'true' ||
        needs.detect-changes.outputs.is_scheduled == 'true' ||
+       needs.release-please.outputs.site_release_created == 'true' ||
        inputs.force_all == true) &&
       (needs.analyze-docs.result == 'success' || needs.analyze-docs.result == 'skipped')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fix release workflow to build and deploy docs when releases are created

## Problem
The release workflow was skipping documentation builds when release-please merged release PRs because:
- Release PRs only change version files (CHANGELOG.md, .release-please-manifest.json)
- `docs_changed` was false
- Build and deploy jobs were skipped

This meant releases were created but documentation wasn't updated on GitHub Pages.

## Solution
- Add `release-please` as dependency to `analyze-docs` and `build-docs` jobs
- Trigger docs build when `site_release_created == 'true'`
- Ensures docs are always built and deployed for new releases

## Test plan
- [x] Workflow file updated with correct dependencies
- [x] Conditional logic includes release creation trigger
- [ ] Next release will verify docs are deployed