### PR TITLE
fix: use correct release-please output for docs build trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       always() && !cancelled() &&
       (needs.detect-changes.outputs.docs_changed == 'true' ||
        needs.detect-changes.outputs.is_scheduled == 'true' ||
-       needs.release-please.outputs.site_release_created == 'true' ||
+       needs.release-please.outputs.releases_created == 'true' ||
        inputs.force_all == true)
     uses: ./.github/workflows/docs-quality.yml
     with:
@@ -105,7 +105,7 @@ jobs:
       always() && !cancelled() &&
       (needs.detect-changes.outputs.docs_changed == 'true' ||
        needs.detect-changes.outputs.is_scheduled == 'true' ||
-       needs.release-please.outputs.site_release_created == 'true' ||
+       needs.release-please.outputs.releases_created == 'true' ||
        inputs.force_all == true) &&
       (needs.analyze-docs.result == 'success' || needs.analyze-docs.result == 'skipped')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

PR #142 attempted to fix docs building on release creation, but used the wrong output variable.

**What happened**: When merging release PR #147, the workflow showed:
- Release v0.6.7 was created ✅
- `site_release_created` output was `false` ❌
- Docs build was skipped ❌

## Root Cause

Release-please action runs TWICE in the same workflow:

1. **First run**: Creates GitHub releases from merged release PRs
   - This is what we want to detect
   - Outputs `releases_created: true` when releases are created

2. **Second run**: Checks if new release PRs are needed
   - Always finds 0 commits (we just released)
   - Sets `site_release_created: false`
   - This is what we were checking - WRONG!

## Solution

Change from checking `site_release_created` (per-component, only for NEW PRs) to `releases_created` (overall, for actual releases).

**Before**:
```yaml
needs.release-please.outputs.site_release_created == 'true'
```

**After**:
```yaml
needs.release-please.outputs.releases_created == 'true'
```

## Verification

Testing with the actual release run (#147):

1. Merged this PR
2. Wait for release-please to create/update release PR
3. Merge release PR
4. **Verify docs jobs run** (analyze-docs, build-docs, deploy-docs)
5. **Verify GitHub Pages deployment**

## Related

- PR #142 - Initial (incorrect) fix attempt
- Run 20013139455 - Proof that site_release_created was false