### PR TITLE
docs: add orphaned files to navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -274,7 +274,10 @@ nav:
               - Common Patterns: developer-guide/sdlc-hardening/github-apps/patterns.md
               - Operations Guide: developer-guide/sdlc-hardening/github-apps/operations.md
           - Commit Signing: developer-guide/sdlc-hardening/commit-signing.md
-          - Pre-commit Hooks: developer-guide/sdlc-hardening/pre-commit-hooks.md
+          - Pre-commit Hooks:
+              - developer-guide/sdlc-hardening/pre-commit-hooks.md
+              - Implementation Patterns: developer-guide/sdlc-hardening/pre-commit-hooks-patterns.md
+          - Vulnerability Scanning: developer-guide/sdlc-hardening/vulnerability-scanning.md
           - SBOM Generation: developer-guide/sdlc-hardening/sbom-generation.md
           - Audit Evidence: developer-guide/sdlc-hardening/audit-evidence.md
           - Implementation Roadmap:


### PR DESCRIPTION
## Summary

Add two orphaned documentation files to the MkDocs navigation:
- `pre-commit-hooks-patterns.md` (281 lines) - Implementation patterns for pre-commit hooks
- `vulnerability-scanning.md` (336 lines) - Zero-vulnerability container scanning guide

## Problem

MkDocs build showed these files existed but weren't in the nav configuration. MkDocs `strict` mode only checks for broken links and build warnings, not orphaned files.

## Changes

- Restructured Pre-commit Hooks nav item to include Implementation Patterns sub-page
- Added Vulnerability Scanning as top-level item under SDLC Hardening

## Verification

- [x] MkDocs build completes without orphaned file warnings
- [x] Both files are now accessible in navigation
