### PR TITLE
fix: update readability action reference from @1 to @latest

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Analyze documentation
-        uses: adaptive-enforcement-lab/readability@1
+        uses: adaptive-enforcement-lab/readability@latest
         with:
           path: docs/
           check: ${{ inputs.fail_on_threshold }}

--- a/docs/blog/posts/2025-12-12-harden-sdlc-before-audit.md
+++ b/docs/blog/posts/2025-12-12-harden-sdlc-before-audit.md
@@ -304,7 +304,7 @@ Here's the phased approach that works:
 - Week 11: Audit simulation
 - Week 12: Remediation and runbook
 
-See [Implementation Roadmap](../../developer-guide/sdlc-hardening/implementation-roadmap.md) for detailed timelines.
+See [Implementation Roadmap](../../developer-guide/sdlc-hardening/implementation-roadmap/index.md) for detailed timelines.
 
 ---
 

--- a/docs/blog/posts/2025-12-13-policy-as-code-kyverno.md
+++ b/docs/blog/posts/2025-12-13-policy-as-code-kyverno.md
@@ -78,7 +78,7 @@ Kyverno enforces policies at multiple layers:
 
 - **[Kyverno Basics](../../developer-guide/sdlc-hardening/policy-as-code/kyverno/index.md)** - Installation, validation policies, audit vs enforce modes
 - **[Policy Patterns](../../developer-guide/sdlc-hardening/policy-as-code/kyverno/policy-patterns.md)** - Resource limits, image provenance, required labels, mutations
-- **[Testing and Exceptions](../../developer-guide/sdlc-hardening/policy-as-code/kyverno/testing.md)** - Policy testing, exception management, troubleshooting
+- **[Testing and Exceptions](../../developer-guide/sdlc-hardening/policy-as-code/kyverno/testing-approaches.md)** - Policy testing, exception management, troubleshooting
 - **[CI/CD Integration](../../developer-guide/sdlc-hardening/policy-as-code/kyverno/ci-cd-integration.md)** - Pre-deploy validation, monitoring, policy lifecycle
 
 ---


### PR DESCRIPTION
## Summary

Fixes the scheduled release pipeline failures caused by ambiguous action reference.

## Changes

- Updated `.github/workflows/docs-quality.yml` to use `@latest` instead of `@1`
- Fixed broken documentation links in blog posts

## Problem

The `@1` reference in `adaptive-enforcement-lab/readability@1` was being interpreted as a shortened commit SHA instead of a version tag, causing the action resolution to fail with:

```
Unable to resolve action `adaptive-enforcement-lab/readability@1`, 
the provided ref `1` is the shortened version of a commit SHA
```

## Solution

Changed to `@latest` tag which points to readability 1.3.1. This avoids the ambiguity and will track the latest release.

## Additional Fixes

Fixed broken links discovered during pre-commit validation:
- `implementation-roadmap.md` → `implementation-roadmap/index.md`
- `kyverno/testing.md` → `kyverno/testing-approaches.md`