### PR TITLE
feat: add OpenSSF Best Practices Badge blog post

### DIFF
--- a/docs/blog/posts/2025-12-04-pre-commit-security-gates.md
+++ b/docs/blog/posts/2025-12-04-pre-commit-security-gates.md
@@ -26,7 +26,7 @@ Pre-commit hooks stop this before it starts.
 CI catches security issues after they're committed. By then:
 
 - Code is in git history (even if the PR never merges)
-- Secrets, if committed, are already exposed
+- Secrets, if committed, are already exposed (we later added TruffleHog scanning to catch this—see [OpenSSF Certification](2025-12-17-openssf-badge-two-hours.md))
 - Audit trails show violations happened
 - Fixing requires force-push or explanation
 

--- a/docs/blog/posts/2025-12-12-harden-sdlc-before-audit.md
+++ b/docs/blog/posts/2025-12-12-harden-sdlc-before-audit.md
@@ -22,8 +22,6 @@ Auditors don't want to hear what you say you do. They want to see what the syste
 
 <!-- more -->
 
----
-
 ## The Confrontation
 
 The auditor opened our GitHub organization. First question: "Show me how you enforce code review."
@@ -75,8 +73,6 @@ Red and orange layers? "Best effort." Green and blue? Actual enforcement.
 
 Auditors only care about what can't be bypassed.
 
----
-
 ## What We Built
 
 In 30 days, we transformed from documentation to enforcement. Here's what actually worked.
@@ -99,8 +95,6 @@ The auditor pointed to the `enforce_admins` setting. "This is what I need to see
 
 See [Branch Protection Enforcement](../../developer-guide/sdlc-hardening/branch-protection.md) for full implementation.
 
----
-
 ### Status Checks: CI as Gatekeeper
 
 We made CI failures block merges. No green checkmarks, no deployment.
@@ -117,8 +111,6 @@ required_status_checks:
 Untested code can't merge. Vulnerable containers can't deploy. The pipeline decides, not developers.
 
 See [Required Status Checks](../../developer-guide/sdlc-hardening/status-checks/index.md) for patterns.
-
----
 
 ### Pre-commit Hooks: First Defense
 
@@ -138,8 +130,6 @@ The commit was blocked. The secret never entered git history.
 Pre-commit hooks are bypassable (`--no-verify`), so we also validate in CI. Defense in depth.
 
 See [Pre-commit Security Gates](2025-12-04-pre-commit-security-gates.md) and [Pre-commit Hooks Guide](../../developer-guide/sdlc-hardening/pre-commit-hooks.md).
-
----
 
 ### GitHub Apps: Authentication Without People
 
@@ -161,8 +151,6 @@ The auditor approved immediately.
 
 See [GitHub Apps for Machine Authentication](../../developer-guide/sdlc-hardening/github-apps/index.md) for migration guide.
 
----
-
 ### Signed Commits: Non-Repudiation
 
 Anyone can set `git config user.name "Mark Cheret"`. GPG signatures can't be forged without the private key.
@@ -175,8 +163,6 @@ gpg: Good signature from "Mark Cheret <mark@example.com>"
 Branch protection can require signatures. Unsigned commits can't be pushed.
 
 See [Commit Signing](../../developer-guide/sdlc-hardening/commit-signing.md) for setup.
-
----
 
 ### SBOM Generation: Supply Chain Visibility
 
@@ -195,9 +181,9 @@ We generated SBOMs for every build:
 
 Auditor could verify: No GPL licenses. No HIGH CVEs. Dependencies matched versions.
 
-See [SBOM Generation](../../developer-guide/sdlc-hardening/sbom-generation.md) and [Zero-Vulnerability Pipelines](2025-12-15-zero-vulnerability-pipelines.md).
+These same practices earned our readability project OpenSSF Best Practices certification—read about the [2-hour documentation sprint](2025-12-17-openssf-badge-two-hours.md).
 
----
+See [SBOM Generation](../../developer-guide/sdlc-hardening/sbom-generation.md) and [Zero-Vulnerability Pipelines](2025-12-15-zero-vulnerability-pipelines.md).
 
 ### Runtime Enforcement: Kyverno
 
@@ -232,8 +218,6 @@ Pods without resource limits get rejected. Policy runs in the cluster, not just 
 
 See [Policy-as-Code with Kyverno](2025-12-13-policy-as-code-kyverno.md) for end-to-end enforcement.
 
----
-
 ## The Evidence Collection
 
 Auditors sampled March 2025. "Show me PRs merged that month."
@@ -259,8 +243,6 @@ We had monthly archives of branch protection configs, workflow runs, and SBOMs. 
 
 See [Audit Evidence Collection](../../developer-guide/sdlc-hardening/audit-evidence.md) for retention strategies.
 
----
-
 ## The Transformation
 
 | Control | Before (Documentation) | After (Enforcement) |
@@ -274,8 +256,6 @@ See [Audit Evidence Collection](../../developer-guide/sdlc-hardening/audit-evide
 | Runtime | "Follow deployment standards" | Kyverno enforces policies in-cluster |
 
 The right column survives audit scrutiny. The left doesn't.
-
----
 
 ## The 90-Day Roadmap
 
@@ -330,8 +310,6 @@ The audit trail should show: "Bypass used 3 times in 2024. All reviewed within 2
 
 Not: "We bypass whenever it's convenient."
 
----
-
 ## The Audit Result
 
 Day 18. The auditor closed their laptop.
@@ -341,8 +319,6 @@ Day 18. The auditor closed their laptop.
 We passed.
 
 Not because of our documentation. Because we built systems that make security inevitable.
-
----
 
 ## Where to Start
 
@@ -357,8 +333,6 @@ The full stack includes pre-commit hooks, commit signing, SBOMs, and runtime pol
 
 See the [SDLC Hardening section](../../developer-guide/sdlc-hardening/index.md) for complete implementation guides.
 
----
-
 ## Related Patterns
 
 The full defense stack:
@@ -367,7 +341,5 @@ The full defense stack:
 - **[Zero-Vulnerability Pipelines](2025-12-15-zero-vulnerability-pipelines.md)** - Block vulnerable images
 - **[Policy-as-Code with Kyverno](2025-12-13-policy-as-code-kyverno.md)** - Runtime admission control
 - **[Environment Progression Testing](2025-12-16-environment-progression-testing.md)** - Validate before production
-
----
 
 *The Monday email became a 90-day transformation. Documentation was replaced with automation. Controls were proven, not promised. The audit passed. Security became inevitable.*

--- a/docs/blog/posts/2025-12-17-openssf-badge-two-hours.md
+++ b/docs/blog/posts/2025-12-17-openssf-badge-two-hours.md
@@ -1,0 +1,166 @@
+---
+date: 2025-12-17
+authors:
+  - mark
+categories:
+  - DevSecOps
+  - Open Source
+  - Quality Assurance
+description: >-
+  Earned OpenSSF Best Practices certification in 2 hours. The gap wasn't code quality—it was contributor documentation.
+slug: openssf-badge-two-hours
+---
+
+# OpenSSF Best Practices Badge in 2 Hours: The Documentation Gap
+
+Six pull requests. Two hours. OpenSSF Best Practices badge earned.
+
+The readability project passed certification on December 13, 2025. But the work didn't start that day—it started months earlier when we built the infrastructure the badge measures.
+
+<!-- more -->
+
+---
+
+## What We Already Had
+
+Before touching the OpenSSF questionnaire, the project had:
+
+### Test Coverage: 97-100%
+
+| Package          | Coverage |
+|------------------|----------|
+| cmd/readability  | 97.5%    |
+| pkg/analyzer     | 99.1%    |
+| pkg/config       | 100.0%   |
+| pkg/markdown     | 98.8%    |
+| pkg/output       | 99.6%    |
+
+95% minimum enforced in CI. Race detector enabled. No exceptions.
+
+**Security Scanning:**
+
+- Trivy vulnerability scanning with SARIF output to GitHub Security
+- CycloneDX SBOM generation uploaded as artifacts
+- Dependabot watching dependencies
+- Private vulnerability reporting enabled
+
+**Code Quality:**
+
+- golangci-lint with comprehensive ruleset including gosec
+- Zero issues policy—every commit must pass
+- gofmt enforcement
+- Standard Go tooling (`go build`, `go test`)
+
+**CI/CD:**
+
+- Automated testing on every PR
+- Release-Please for semantic versioning
+- Git tags for all releases (v1.0.0 through v1.5.0)
+
+Badge criteria: mostly already met. What was missing? **Contributor documentation.**
+
+---
+
+## The 2-Hour Documentation Sprint
+
+**21:05** - PR #93: CONTRIBUTING.md
+
+- Bug reporting process
+- Feature request guidelines
+- Development setup
+- Code style requirements
+- Testing requirements (95% threshold documented)
+
+**21:17** - PR #94: SECURITY.md
+
+- Supported versions table
+- Private disclosure via GitHub Security Advisories
+- Response timeline commitments:
+  - Initial Response: Within 48 hours
+  - Status Update: Within 7 days
+  - Resolution Target: Within 90 days
+
+**21:18** - PR #95: Issue templates
+
+- `.github/ISSUE_TEMPLATE/bug_report.yml`
+- `.github/ISSUE_TEMPLATE/feature_request.yml`
+- Config redirecting security issues to private reporting
+
+**21:19** - PR #96: Enable blank issues
+
+- Allow free-form alongside structured templates
+
+**21:35** - PR #98: TruffleHog CI integration
+
+- Secret scanning with `--only-verified` flag
+- Added to existing security job
+
+**21:42** - PR #99: Badge in README
+
+- Display the certification
+
+Done. Badge earned.
+
+---
+
+## The Lesson: Build First, Document Second
+
+The OpenSSF badge measures what matters:
+
+- Test coverage (we had it)
+- Security scanning (already running)
+- Static analysis (golangci-lint)
+- Vulnerability response (Dependabot watching)
+- Build system (standard Go tooling)
+
+What it **also** measures: whether you tell contributors how to work with you.
+
+CONTRIBUTING.md isn't bureaucracy. It's a contract: "Here's how we work. Here's what we expect."
+
+SECURITY.md isn't compliance theater. It's a public commitment: "Report vulnerabilities here. We'll respond within 48 hours."
+
+Issue templates aren't friction. They're structure that saves time for both sides.
+
+---
+
+## The Economics of Certification
+
+**Cost**: 2 hours of documentation work
+
+**Value**: Public signal that the project follows security best practices
+
+For a well-maintained project, the badge is trivial to earn. For a poorly-maintained project, it exposes gaps that should be fixed anyway.
+
+Either way, you win.
+
+---
+
+## Tactical Takeaways
+
+1. **Build security infrastructure before you need a badge.** High coverage, scanning, and quality tools pay off regardless.
+
+2. **Documentation is the certification gap.** Most projects have the practices—they just haven't documented them.
+
+3. **GitHub's security features integrate perfectly.** Private reporting, Dependabot, security advisories—all free, all OpenSSF-aligned.
+
+4. **N/A is valid.** Many criteria (especially cryptography) don't apply to all projects. Mark them N/A with explanation.
+
+5. **Low effort, high signal.** For projects with good practices, certification is 2 hours of documentation.
+
+!!! tip "Start With Infrastructure"
+
+    Don't chase the badge first. Build the security infrastructure (testing, scanning, CI/CD), then document it. The badge becomes trivial when practices are already solid.
+
+---
+
+## The Badge
+
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11610/badge)](https://www.bestpractices.dev/en/projects/11610)
+
+View the full certification: [https://www.bestpractices.dev/en/projects/11610](https://www.bestpractices.dev/en/projects/11610)
+
+Repository: [adaptive-enforcement-lab/readability](https://github.com/adaptive-enforcement-lab/readability)
+
+---
+
+**Next**: [Zero-Vulnerability Pipelines](2025-12-15-zero-vulnerability-pipelines.md) - How Trivy, SBOM, and GitHub Security integration satisfy OpenSSF vulnerability criteria.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,15 +18,16 @@ Adaptive Enforcement Lab is actively building. Here's what's coming.
 
     We're building a content pipeline for actionable security guidance. Recent posts:
 
+    - ✅ **[OpenSSF Best Practices Badge in 2 Hours](blog/posts/2025-12-17-openssf-badge-two-hours.md)**
+    - ✅ **[Policy-as-Code with Kyverno](blog/posts/2025-12-13-policy-as-code-kyverno.md)**
     - ✅ **[How to Harden Your SDLC Before the Audit Comes](blog/posts/2025-12-12-harden-sdlc-before-audit.md)**
-    - ✅ **[ConfigMap as Cache Pattern](blog/posts/2025-12-03-configmap-cache-zero-api.md)**
     - ✅ **[Pre-commit Hooks as Security Gates](blog/posts/2025-12-04-pre-commit-security-gates.md)**
 
     Coming next:
 
-    - Policy-as-code with Kyverno
     - Zero-vulnerability container pipelines
     - Environment progression testing
+    - Event-driven deployments with Argo
 
 !!! info "Community Hub"
 


### PR DESCRIPTION
## Summary

- Add new blog post about achieving OpenSSF Best Practices Badge certification in 2 hours
- Add strategic backlinks from related posts (pre-commit security gates, SDLC hardening)
- Update roadmap with completed content
- Fix broken documentation links discovered during commit (implementation-roadmap, kyverno/testing)

## Content Details

The new post covers:
- Test coverage (97-100%) and security scanning infrastructure already in place
- 2-hour documentation sprint (CONTRIBUTING.md, SECURITY.md, issue templates)
- The lesson: build security infrastructure first, document second
- Tactical takeaways for other projects seeking certification

## Links Fixed

- `implementation-roadmap.md` → `implementation-roadmap/index.md`
- `kyverno/testing.md` → `kyverno/testing-approaches.md`

## Test Plan

- [x] All pre-commit hooks passed (markdownlint, readability, mkdocs build)
- [x] Backlinks validated and functional
- [x] Roadmap updated correctly