### PR TITLE
feat: add shift-left validation to Kyverno blog post

### DIFF
--- a/docs/blog/posts/2025-12-13-policy-as-code-kyverno.md
+++ b/docs/blog/posts/2025-12-13-policy-as-code-kyverno.md
@@ -52,23 +52,28 @@ Policy becomes code, not documentation.
 
 ## OPA vs Kyverno
 
-Two main options for policy enforcement:
+Two options for Kubernetes policy enforcement:
 
 ### Open Policy Agent (OPA)
 
-- General-purpose policy engine
-- Rego language (new language to learn)
-- Works everywhere (K8s, CI/CD, APIs)
-- More powerful, more complex
+- **Language**: Rego (purpose-built policy language)
+- **Scope**: General-purpose (K8s, APIs, cloud services, application logic)
+- **Learning curve**: Steeper (new language, abstract concepts)
+- **Use case**: Multi-platform policy enforcement across entire stack
 
 ### Kyverno
 
-- Kubernetes-native
-- YAML policies (same as manifests)
-- Built for K8s admission control
-- Simpler learning curve
+- **Language**: YAML + JMESPath (no new language to learn)
+- **Scope**: Kubernetes-focused (admission control, CLI validation, mutations, generation)
+- **Learning curve**: Gentler (if you know K8s YAML, you know Kyverno)
+- **Use case**: Kubernetes policy enforcement with built-in K8s intelligence
 
-For Kubernetes-only enforcement, Kyverno wins on simplicity.
+**Both run in admission control, CI/CD, and local development.** The choice depends on scope:
+
+- **Choose OPA** if you need policies across multiple platforms (databases, APIs, cloud IAM, service mesh)
+- **Choose Kyverno** if your policies are Kubernetes-specific and you want native K8s resource awareness
+
+Neither is "more powerful"—they target different problems.
 
 ---
 


### PR DESCRIPTION
## Summary

Enhance the Kyverno Policy-as-Code blog post to emphasize shift-left enforcement and multiple validation points.

## Changes

### New Section: "Shift Left: CI/CD and Local Validation"

**Local Development**:
- Kyverno CLI installation (`brew install kyverno`)
- Local manifest validation before committing
- Faster feedback loop for developers

**CI/CD Pipeline**:
- Example GitHub Actions workflow to fail builds on policy violations
- Same policies enforced in PR gate as in production

**Kyverno Playground**:
- Link to [playground.kyverno.io](https://playground.kyverno.io/)
- Interactive browser-based policy testing
- Team collaboration and learning resource

### Updated "The Stack" Section

Expanded enforcement layers from 4 to 5, explicitly highlighting that **Kyverno runs at three layers**:

1. Pre-commit hooks (forbidden tech)
2. **Local validation** - `kyverno apply` in developer workflow
3. **CI validation** - Kyverno CLI fails PR builds
4. **Admission control** - Kyverno blocks at Kubernetes API
5. Runtime enforcement (Pod Security Standards)

Emphasizes: **Same policies. Different enforcement points.**

### New Admonition

Added "Three Enforcement Points" tip box explaining defense-in-depth strategy with Kyverno.

## Context

Original post focused heavily on runtime admission control, missing the critical shift-left story. Kyverno's CLI enables policy validation locally and in CI/CD—catching violations before they reach the cluster.

This enhancement aligns with AEL's enforcement-first philosophy and the broader SDLC hardening narrative.

## Test Plan

- [x] All pre-commit hooks passed (markdownlint, readability, mkdocs build)
- [x] Line count: 163 lines (well under 375 limit)
- [x] Links validated (playground.kyverno.io)
- [x] Content structure follows CONTRIBUTING.md standards
- [x] No admonitions above `<!-- more -->` marker

## Related Content

- Complements [SDLC Hardening](https://adaptive-enforcement-lab.com/blog/2025/12/12/harden-sdlc-before-audit/) multi-layer defense narrative
- Aligns with [Pre-commit Security Gates](https://adaptive-enforcement-lab.com/blog/2025/12/04/pre-commit-security-gates/) philosophy