### PR TITLE
chore: add Claude Code files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ __pycache__/
 *.swp
 *.swo
 
+# Claude Code
+.auto-claude/
+.claude_settings.json
+.worktrees/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Problem

Claude Code tool files appear in `git status` output.

## Changes

Add Claude Code local files to `.gitignore`:
- `.auto-claude/` - Agent transcripts and state
- `.claude_settings.json` - Local settings
- `.worktrees/` - Git worktree metadata

## Validation

✅ Files no longer appear in `git status`
✅ No functional impact