### PR TITLE
feat: add mkdocs-build skill for automated validation

### DIFF
--- a/.claude/skills/mkdocs-build.md
+++ b/.claude/skills/mkdocs-build.md
@@ -1,0 +1,21 @@
+---
+name: mkdocs-build
+description: Build and validate MkDocs site using venv if available
+runOn: always
+---
+
+# Build MkDocs Site
+
+Build MkDocs site in strict mode to catch all validation errors.
+
+**CRITICAL**: Use `.venv/bin/mkdocs` if it exists, otherwise fall back to system `mkdocs`.
+
+```bash
+if [ -f .venv/bin/mkdocs ]; then
+    .venv/bin/mkdocs build --strict
+else
+    mkdocs build --strict
+fi
+```
+
+This matches the pre-commit hook configuration exactly.


### PR DESCRIPTION
## Summary

Add `mkdocs-build` skill to automate MkDocs site validation with strict mode checking.

## Changes

- Created `.claude/skills/mkdocs-build.md`
- Skill automatically uses `.venv/bin/mkdocs` if available, falls back to system `mkdocs`
- Runs `mkdocs build --strict` to catch all validation errors
- Matches pre-commit hook behavior for consistency

## Purpose

This skill ensures documentation builds are validated during AI-assisted workflows, catching broken links, missing pages, and configuration errors before commits.

## Testing

- [x] Skill syntax validated
- [x] Matches pre-commit hook configuration
- [x] Virtual environment detection logic tested
- [x] Pre-commit hooks pass

## Checklist

- [x] One logical change per PR
- [x] Clear, descriptive title
- [x] Documentation standards followed
- [x] `mkdocs build` succeeds