### PR TITLE
chore: make mkdocs-build skill direct and authoritative

### DIFF
--- a/.claude/skills/mkdocs-build.md
+++ b/.claude/skills/mkdocs-build.md
@@ -1,21 +1,35 @@
 ---
 name: mkdocs-build
-description: Build and validate MkDocs site using venv if available
+description: Use when modifying documentation, configuration files, or before completing doc-related tasks
 runOn: always
 ---
 
-# Build MkDocs Site
+# MkDocs Build
 
-Build MkDocs site in strict mode to catch all validation errors.
+Run MkDocs build in strict mode. This is the EXACT command from the pre-commit hook.
 
-**CRITICAL**: Use `.venv/bin/mkdocs` if it exists, otherwise fall back to system `mkdocs`.
+## Command
 
 ```bash
-if [ -f .venv/bin/mkdocs ]; then
-    .venv/bin/mkdocs build --strict
-else
-    mkdocs build --strict
-fi
+if [ -f .venv/bin/mkdocs ]; then .venv/bin/mkdocs build --strict; else mkdocs build --strict; fi
 ```
 
-This matches the pre-commit hook configuration exactly.
+**No substitutions. No variations. No "I'll just run mkdocs build".**
+
+## When This Runs
+
+Triggered by changes to:
+
+- `*.md` files
+- `*.yml` or `*.yaml` files
+
+## What --strict Does
+
+Fails on:
+
+- Missing references
+- Invalid links
+- Configuration errors
+- Any MkDocs warnings
+
+**If the build fails, fix the error. Don't disable strict mode.**


### PR DESCRIPTION
## Summary

Remove wishy-washy language and make the skill enforce exact pre-commit hook command with no substitutions or variations.

## Changes

- Update description to focus on WHEN to use (not WHAT it does)
- Remove explanatory language, make commands direct
- Add explicit prohibition against variations
- Add clear enforcement on strict mode requirement

## Files Changed

```
.claude/skills/mkdocs-build.md | 34 ++++++++++++++++++++++++----------
1 file changed, 24 insertions(+), 10 deletions(-)
```

## Validation

- ✅ markdownlint passed
- ✅ mkdocs build --strict passed
- ✅ All pre-commit hooks passed
- ✅ Meets CONTRIBUTING.md requirements

## Context

The skill was too explanatory and left room for interpretation. Now it's direct and matches the exact pre-commit hook implementation with zero tolerance for shortcuts.