### PR TITLE
fix: add missing navigation entries from PR 208

### DIFF
--- a/docs/secure/scorecard/checks/branch-protection/part-1b.md
+++ b/docs/secure/scorecard/checks/branch-protection/part-1b.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Automate branch protection across repositories using Terraform and GitHub Rulesets. Infrastructure-as-code patterns for consistent, auditable enforcement.
+---
+
 # Branch Protection via Terraform
 
 !!! tip "Key Insight"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -481,7 +481,12 @@ nav:
                   - secure/scorecard/checks/release-security.md
                   - Signed-Releases: secure/scorecard/checks/release-security/signed-releases.md
                   - Signed-Releases Advanced: secure/scorecard/checks/release-security/signed-releases-advanced.md
-                  - Packaging: secure/scorecard/checks/release-security/packaging.md
+                  - Packaging:
+                      - secure/scorecard/checks/release-security/packaging.md
+                      - Containers: secure/scorecard/checks/release-security/packaging/containers.md
+                      - Go Modules: secure/scorecard/checks/release-security/packaging/go-modules.md
+                      - NPM: secure/scorecard/checks/release-security/packaging/npm.md
+                      - PyPI: secure/scorecard/checks/release-security/packaging/pypi.md
                   - License: secure/scorecard/checks/release-security/license.md
               - Branch Protection:
                   - secure/scorecard/checks/branch-protection.md


### PR DESCRIPTION
## Summary

Adds missing navigation entries for scorecard packaging documentation and frontmatter that were omitted from PR #208.

## Changes

### Navigation Structure
- **Added packaging subdirectory entries** to `mkdocs.yml`:
  - Containers (`containers.md`)
  - Go Modules (`go-modules.md`)
  - NPM (`npm.md`)
  - PyPI (`pypi.md`)

### Documentation Frontmatter
- **Added description frontmatter** to `branch-protection/part-1b.md` to satisfy pre-commit hook requirements

## Verification

All pre-commit hooks now pass:
- ✅ markdownlint
- ✅ check documentation readability
- ✅ block forbidden technologies
- ✅ check description frontmatter
- ✅ mkdocs build

## Testing

```bash
mkdocs build  # Successful build with complete navigation
pre-commit run --all-files  # All hooks pass
```

## Related

Fixes navigation issues from PR #208 that were flagged by pre-commit hooks.