### PR TITLE
docs: shorten blog index admonition for faster access to posts

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -11,53 +11,7 @@ Field notes from the trenches of DevSecOps automation. Real-world patterns, trou
 
 !!! abstract "What You'll Find Here"
 
-    **DevSecOps & Security**
-
-    - Cloud security hardening (GCP, Kubernetes)
-    - Policy-as-code enforcement and compliance
-    - Supply chain security and SBOM
-    - Risk management for engineers
-    - SDLC hardening strategies
-
-    **CI/CD & Automation**
-
-    - GitHub Actions workflows and automation
-    - GitHub Apps architecture and security
-    - Release engineering and versioned deployments
-    - Pipeline resilience and error handling
-    - Pre-commit hooks and quality gates
-
-    **Engineering Patterns**
-
-    - Idempotency and work avoidance
-    - Error handling and fail-fast patterns
-    - Architecture patterns (Hub & Spoke, Strangler Fig)
-    - Reliability and chaos engineering
-    - Performance optimization
-
-    **Platform & Tools**
-
-    - Kubernetes operations and troubleshooting
-    - Argo Workflows and Argo Events
-    - Go CLI architecture and design
-    - Developer tooling and automation
-    - Git workflows and debugging
-
-    **Culture & Operations**
-
-    - Incident response and playbooks
-    - Security culture transformation
-    - Operational retrospectives
-    - Debugging war stories
-    - Team enablement
-
-    **Quality & Testing**
-
-    - Test-driven development
-    - Code quality and linting
-    - Coverage as security signal
-    - QA automation
-    - Pre-commit validation
+    Security automation patterns, CI/CD hardening techniques, and engineering war stories from production environments. Topics span GitHub Actions security, Kubernetes operations, supply chain protection, and the cultural shifts needed to make security enforceable by default.
 
 !!! tip "Looking for Implementation Guides?"
 


### PR DESCRIPTION
## Summary

Reduced the 'What You'll Find Here' admonition from 30 bullet points to 2 concise sentences, making blog posts accessible without excessive scrolling.

## Problem

The blog index required 3 scrolls to reach actual blog posts due to the lengthy admonition (49 lines across 6 categories). No human will scroll that far.

## Changes

- **Before**: 30 bullet points across 6 categories (DevSecOps, CI/CD, Engineering Patterns, Platform & Tools, Culture & Operations, Quality & Testing)
- **After**: 2 concise sentences capturing key themes (security automation, CI/CD, GitHub Actions, Kubernetes, supply chain, culture)

## Impact

- Blog posts now visible immediately without scrolling
- Admonition length matches other admonitions on the page
- Key themes still communicated effectively

## Files Changed

- `docs/blog/index.md` - Condensed admonition from 49 lines to 3 lines (1 insertion, 47 deletions)

## Checklist

- [x] Clear, descriptive title
- [x] One logical change per PR
- [x] `mkdocs build` succeeds (validated by pre-commit hook)
- [x] Markdownlint passes