### PR TITLE
feat: use Core App token for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,18 @@ jobs:
       site_version: ${{ steps.release.outputs['.--version'] }}
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CORE_APP_ID }}
+          private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
+          owner: adaptive-enforcement-lab
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

Replace `GITHUB_TOKEN` with Core App authentication in the release-please workflow to ensure release PRs trigger `pull_request` events and run build pipelines.

## Changes

- Added Core App token generation step before release-please action
- Replaced `secrets.GITHUB_TOKEN` with Core App token in release-please
- Uses organization secrets `CORE_APP_ID` and `CORE_APP_PRIVATE_KEY`

## Benefits

- ✅ Release PRs now trigger workflows like developer-created PRs
- ✅ No need for dual-trigger workaround (push on release-please branches)
- ✅ Proper machine identity with complete audit trail
- ✅ Granular permissions and higher rate limits (5000 req/hour per installation)

## Technical Details

**Before**: Release-please PRs created with `GITHUB_TOKEN` don't trigger `pull_request` events → build pipeline never runs → branch protection blocks merge

**After**: Release-please PRs created with Core App token trigger workflows normally → builds run → checks pass → merge allowed

## Related Documentation

- Blog post: [The Real Fix for Release-Please Triggers](docs/blog/posts/2025-12-02-the-real-fix-for-release-please-triggers.md)
- Setup guide: [GitHub Core App Setup](docs/secure/github-apps/index.md)

## Test Plan

- [x] AEL CORE App created and installed on organization
- [x] Organization secrets configured (`CORE_APP_ID`, `CORE_APP_PRIVATE_KEY`)
- [x] Workflow syntax validated with actionlint
- [ ] Test with actual release-please PR creation (will verify after merge)

## Files Changed

- `.github/workflows/release.yml` - Added Core App token generation