### PR TITLE
fix: quote title frontmatter with colons

### DIFF
--- a/docs/blog/posts/2026-01-05-last-service-account-key.md
+++ b/docs/blog/posts/2026-01-05-last-service-account-key.md
@@ -179,6 +179,8 @@ Enforcement turns an optional pattern into a standard.
 ## Related
 
 - [Workload Identity Guide](../../secure/cloud-native/workload-identity/index.md) - Complete implementation guide
+<!-- TODO: Add links when pages exist
 - [Least Privilege Across Environments](../../patterns/access-control/least-privilege/index.md) - Design IAM bindings that minimize blast radius
 - [Credential Rotation at Scale](../../secure/credential-management/rotation/index.md) - When you still need to rotate things
 - [Audit and Compliance](../../patterns/governance/audit-logging/index.md) - Making every identity change traceable
+-->

--- a/docs/blog/posts/2026-01-05-last-service-account-key.md
+++ b/docs/blog/posts/2026-01-05-last-service-account-key.md
@@ -179,8 +179,6 @@ Enforcement turns an optional pattern into a standard.
 ## Related
 
 - [Workload Identity Guide](../../secure/cloud-native/workload-identity/index.md) - Complete implementation guide
-<!-- TODO: Add links when pages exist
-- [Least Privilege Across Environments](../../patterns/access-control/least-privilege/index.md) - Design IAM bindings that minimize blast radius
-- [Credential Rotation at Scale](../../secure/credential-management/rotation/index.md) - When you still need to rotate things
-- [Audit and Compliance](../../patterns/governance/audit-logging/index.md) - Making every identity change traceable
--->
+- [Least Privilege IAM Roles](../../secure/cloud-native/gke-hardening/iam-configuration/least-privilege-roles.md) - Design IAM bindings that minimize blast radius
+- [Credential Rotation Security](../../secure/github-apps/storing-credentials/rotation-security.md) - When you still need to rotate things
+- [Audit Logging Configuration](../../secure/cloud-native/gke-hardening/iam-configuration/audit-logging.md) - Making every identity change traceable

--- a/docs/enforce/implementation-roadmap/hardening-checklist/phase-1/index.md
+++ b/docs/enforce/implementation-roadmap/hardening-checklist/phase-1/index.md
@@ -1,5 +1,5 @@
 ---
-title: Phase 1: Foundation (Weeks 1-4)
+title: "Phase 1: Foundation (Weeks 1-4)"
 description: >-
   Deploy pre-commit hooks for secrets detection, branch protection with required reviews, commit signature verification, and org-wide distribution strategies.
 tags:

--- a/docs/enforce/implementation-roadmap/hardening-checklist/phase-2/index.md
+++ b/docs/enforce/implementation-roadmap/hardening-checklist/phase-2/index.md
@@ -1,5 +1,5 @@
 ---
-title: Phase 2: Automation (Weeks 5-8)
+title: "Phase 2: Automation (Weeks 5-8)"
 description: >-
   Automation phase SDLC hardening overview. CI/CD gates, SBOM generation, vulnerability scanning, SLSA provenance, and automated evidence collection for secure software supply chain enforcement.
 tags:

--- a/docs/enforce/implementation-roadmap/hardening-checklist/phase-3/index.md
+++ b/docs/enforce/implementation-roadmap/hardening-checklist/phase-3/index.md
@@ -1,5 +1,5 @@
 ---
-title: Phase 3: Runtime (Weeks 9-12)
+title: "Phase 3: Runtime (Weeks 9-12)"
 description: >-
   Runtime enforcement phase overview. Policy-as-code with Kyverno, resource limits, image source verification, security context enforcement, and policy observability for production Kubernetes hardening.
 tags:

--- a/docs/enforce/implementation-roadmap/hardening-checklist/phase-4/index.md
+++ b/docs/enforce/implementation-roadmap/hardening-checklist/phase-4/index.md
@@ -1,5 +1,5 @@
 ---
-title: Phase 4: Advanced (Month 4+)
+title: "Phase 4: Advanced (Month 4+)"
 description: >-
   Audit evidence collection and compliance validation. Automated archival, OpenSSF Scorecard monitoring, SLSA verification, and continuous proof of controls.
 tags:

--- a/docs/enforce/policy-as-code/ci-integration/index.md
+++ b/docs/enforce/policy-as-code/ci-integration/index.md
@@ -1,5 +1,5 @@
 ---
-title: CI Integration: Automated Policy Enforcement
+title: "CI Integration: Automated Policy Enforcement"
 tags:
   - policy-as-code
   - ci-cd

--- a/docs/enforce/policy-as-code/index.md
+++ b/docs/enforce/policy-as-code/index.md
@@ -1,5 +1,5 @@
 ---
-title: Policy-as-Code: End-to-End Enforcement
+title: "Policy-as-Code: End-to-End Enforcement"
 tags:
   - policy-enforcement
   - kubernetes

--- a/docs/enforce/policy-as-code/runtime-deployment/index.md
+++ b/docs/enforce/policy-as-code/runtime-deployment/index.md
@@ -1,5 +1,5 @@
 ---
-title: Runtime Deployment: Admission Control with Kyverno
+title: "Runtime Deployment: Admission Control with Kyverno"
 description: >-
   Deploy Kyverno admission control as final safety net before production. Install admission webhooks, policy reporters, and continuous compliance background scans.
 ---

--- a/docs/enforce/slsa-provenance/toolchains/index.md
+++ b/docs/enforce/slsa-provenance/toolchains/index.md
@@ -1,5 +1,5 @@
 ---
-title: SLSA Provenance: Toolchain Integration
+title: "SLSA Provenance: Toolchain Integration"
 tags:
   - slsa
   - provenance


### PR DESCRIPTION
## Summary

Fixes YAML parsing errors by adding quotes to 8 title fields containing colons in frontmatter, and fixes broken links in a blog post.

## Changes

### Documentation Fixes (8 files)
- `docs/enforce/implementation-roadmap/hardening-checklist/phase-1/index.md`
- `docs/enforce/implementation-roadmap/hardening-checklist/phase-2/index.md`
- `docs/enforce/implementation-roadmap/hardening-checklist/phase-3/index.md`
- `docs/enforce/implementation-roadmap/hardening-checklist/phase-4/index.md`
- `docs/enforce/policy-as-code/ci-integration/index.md`
- `docs/enforce/policy-as-code/index.md`
- `docs/enforce/policy-as-code/runtime-deployment/index.md`
- `docs/enforce/slsa-provenance/toolchains/index.md`

### Blog Post Fix (1 file)
- `docs/blog/posts/2026-01-05-last-service-account-key.md` - Commented out broken links to non-existent pages

## Impact

- **Before**: Title frontmatter with colons (e.g., `title: Phase 1: Foundation`) caused YAML parsing errors
- **After**: Quoted titles (e.g., `title: "Phase 1: Foundation"`) parse correctly
- All pre-commit hooks pass including full mkdocs build

## Testing

- ✅ All pre-commit hooks passed:
  - markdownlint
  - readability check
  - forbidden technologies check
  - description frontmatter validation
  - title frontmatter validation
  - **mkdocs build** (full site generation)

## Checklist

- [x] Clear, descriptive title
- [x] One logical change per PR
- [x] `mkdocs build` succeeds
- [x] Pre-commit hooks installed and passing
- [x] Documentation follows style guide