### PR TITLE
docs: document the skills marketplace, add blog post, correct roadmap

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -19,4 +19,4 @@ Field notes from the trenches of DevSecOps automation. Real-world patterns, trou
 
 !!! info "What's Coming"
 
-    Check the [Roadmap](../roadmap.md) for upcoming content including Claude Code skills marketplace, work avoidance deep dives, and community features.
+    Check the [Roadmap](../roadmap.md) for upcoming content including work avoidance deep dives, skills marketplace documentation, and community features.

--- a/docs/blog/posts/2026-07-21-docs-nobody-read.md
+++ b/docs/blog/posts/2026-07-21-docs-nobody-read.md
@@ -1,0 +1,107 @@
+---
+title: The Docs Nobody Read
+date: 2026-07-21
+authors:
+  - mark
+categories:
+  - Documentation
+  - AI Agents
+  - DevSecOps
+  - Developer Tools
+description: >-
+  Writing documentation is an act of hope. Hope is not a delivery mechanism. So the docs learned to install themselves.
+slug: docs-nobody-read
+---
+# The Docs Nobody Read
+
+Two hundred pages of hard-won patterns. Every one of them paid for in production incidents. Nobody opened them.
+
+<!-- more -->
+
+## The Pride Phase
+
+There is a specific satisfaction in finishing a documentation site. The nav tree balances. The cross-links resolve. Every pattern you bled for in some 3AM incident is now a clean page with a diagram and a rationale section.
+
+I had that satisfaction for about six weeks.
+
+The site covered enforcement, hardening, build engineering, reliability patterns. Not theory. Scar tissue. The kind of knowledge that only exists because something broke badly enough that you rewrote how the whole team works.
+
+I shipped it. I linked it in onboarding. I referenced it in PR reviews.
+
+And then I watched the analytics do nothing.
+
+## The Silence
+
+Documentation failure is quiet. Nothing alerts. No pipeline goes red. There is no dashboard tile for *this knowledge is not reaching anyone*.
+
+The pages were fine. The writing was fine. The search worked. That was the uncomfortable part. I could not point at a defect. The artifact was correct and the outcome was still zero.
+
+Meanwhile the same questions kept arriving in Slack. Questions the docs answered. Sometimes with a link to the exact page in the thread above, unclicked.
+
+I told myself it was a discoverability problem. It was not.
+
+## Watching Someone Not Read It
+
+The moment it broke open was mundane.
+
+An engineer needed a hardened release workflow. The pattern was documented: permissions, pinning, provenance, the lot. Three clicks from the homepage.
+
+They did not go to the site. They asked their agent.
+
+And the agent produced a workflow that was *fine*. Competent, confident, well-meaning. Generic-fine. Tag-pinned actions. Default token permissions. Every recommendation was defensible and not one of them carried a single thing the team had learned the hard way.
+
+The knowledge was not competing with ignorance. It was competing with a plausible answer that arrived in four seconds without leaving the editor.
+
+Documentation loses that race every time. It is not close.
+
+## The Part That Stung
+
+Here is the thing I had been avoiding.
+
+Documentation is **pull**. It sits there, correct and patient, and waits for someone to want it enough to go and get it.
+
+Every page is a small bet that a future engineer will feel uncertain at exactly the right moment, phrase their uncertainty in a way that matches your headings, and choose reading over guessing.
+
+Everything else we build is **push**. Pre-commit hooks do not wait to be wanted. Admission controllers do not hope you read the policy. CI gates do not care about your intent. That is the entire premise of this project: enforcement over recommendation, gravity over guidance.
+
+I had been running that philosophy on infrastructure and running the opposite one on knowledge.
+
+The docs were the least enforced thing I owned. I had written two hundred pages of arguments for automation, by hand, into a format that requires a human to voluntarily go looking.
+
+That is not a knowledge base. That is a monument.
+
+## Making the Docs Show Up Uninvited
+
+The fix was not more docs. It was not better SEO or a friendlier nav or a search box with fuzzy matching.
+
+The fix was accepting where the work actually happens now. Inside the agent, in the editor, at the moment the code gets written. And putting the knowledge *there*, unasked.
+
+So the same markdown that renders this site now compiles into skills the agent loads directly. Same source. Same patterns. Same scar tissue. Different delivery: the knowledge arrives at the moment of authorship instead of waiting to be summoned.
+
+**117 skills**, across four collections: patterns, enforce, secure, build. Not one of them hand-authored. Every one generated from the pages nobody was reading, which means the docs and the skills cannot drift, because they are the same artifact wearing different clothes.
+
+The engineer who asked their agent for a release workflow now gets the pinned, least-privilege, provenance-carrying version. Not because they read the page. Because the page is in the room.
+
+!!! success "Gravity, Not Guidance"
+    The best documentation is the kind that stops being optional. Not by shouting louder. By moving to where the decision actually gets made.
+
+## What I Actually Believe Now
+
+Writing documentation is an act of hope. You write down what you learned and you hope it finds the person who needs it before they learn it the same expensive way you did.
+
+Hope is not a delivery mechanism.
+
+If the knowledge matters enough to write down, it matters enough to enforce. And enforcement means it shows up whether or not anyone went looking: in the hook, in the gate, in the policy, and now in the agent that is doing the typing.
+
+The docs did not need more readers.
+
+They needed to stop being a place you go, and start being a thing that happens to you.
+
+!!! warning "The Honest Caveat"
+    This does not make the writing optional. Generated skills are only as good as the source. Garbage patterns compile into garbage skills, delivered faster and with more authority. The pipeline is a multiplier, not a substitute for knowing what you are talking about.
+
+---
+
+**Try it:** the marketplace lives at [adaptive-enforcement-lab/claude-skills](https://github.com/adaptive-enforcement-lab/claude-skills).
+
+**Related:** [Automation Over Documentation](../../about/principles.md) · [Build Engineering](../../build/index.md) · [Enforcement Patterns](../../enforce/index.md)

--- a/docs/build/documentation-as-skills/ci-automation.md
+++ b/docs/build/documentation-as-skills/ci-automation.md
@@ -1,0 +1,195 @@
+---
+title: CI Automation
+description: >-
+  Trigger skill regeneration from documentation changes across repositories using GitHub App authentication, work avoidance, and conditional PR creation.
+tags:
+  - ci-cd
+  - github-actions
+  - automation
+---
+# CI Automation
+
+Regenerating skills automatically when documentation changes, across two repositories, without a human in the loop.
+
+## The Cross-Repository Problem
+
+The documentation and the generated skills live in separate repositories. A push to the docs repository must reach the skills repository, which then checks out both, runs the generator, and publishes the result.
+
+```mermaid
+graph LR
+    A[Docs repo:<br/>push to main] -->|repository_dispatch| B[Skills repo:<br/>generate workflow]
+    B --> C[Checkout both repos]
+    C --> D[Build + run generator]
+    D --> E{Output changed?}
+    E -->|No| F[Exit: nothing to do]
+    E -->|Yes| G[Commit]
+    G --> H{Trigger type?}
+    H -->|Release PR| I[Push to existing branch]
+    H -->|Dispatch| J[Force-push + open PR]
+```
+
+## Triggers
+
+Three entry points, each serving a different need:
+
+```yaml
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [docs-updated]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+```
+
+`repository_dispatch` is the cross-repository signal. `workflow_dispatch` allows manual regeneration. The `pull_request` trigger exists for a narrower purpose, keeping the catalog in step with version bumps, and is gated to release branches only:
+
+```yaml
+jobs:
+  generate:
+    if: >-
+      github.event_name != 'pull_request' ||
+      startsWith(github.head_ref, 'release-please--')
+```
+
+Without that guard, every pull request would regenerate skills.
+
+## Authentication
+
+`GITHUB_TOKEN` cannot trigger downstream workflows. A commit pushed with it will not start CI, which silently breaks the chain from regeneration to release. A GitHub App token does not have this limitation.
+
+```yaml
+- uses: actions/create-github-app-token@v2
+  id: app-token
+  with:
+    app-id: ${{ secrets.CORE_APP_ID }}
+    private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
+    owner: example-org
+```
+
+The token is org-scoped, so the same credential checks out both repositories and drives the `gh` CLI.
+
+!!! tip "One App, Many Repositories"
+    Org-scoped App installation tokens remove per-repository deploy keys entirely.
+
+    See [GitHub Apps](../../secure/github-apps/index.md) for setup, [Authentication Flows](../../secure/github-apps/authentication-flows.md) for token generation, and [Installation Scopes](../../secure/github-apps/installation-scopes.md) for scoping patterns.
+
+## Generation Step
+
+Both repositories are checked out, the generator is built from source, and it runs against the documentation checkout:
+
+```yaml
+- uses: actions/checkout@v5
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+
+- uses: actions/checkout@v5
+  with:
+    repository: example-org/docs-site
+    path: docs-src
+    token: ${{ steps.app-token.outputs.token }}
+
+- uses: actions/setup-go@v6
+  with:
+    go-version: '1.25'
+
+- run: go build -o ../bin/skillgen ./cmd/skillgen
+  working-directory: skillgen
+
+- run: |
+    ./bin/skillgen \
+      --source docs-src/docs \
+      --output plugins \
+      --plugin-metadata ./plugin-metadata.json \
+      --release-manifest ./.release-please-manifest.json \
+      --templates skillgen/templates
+```
+
+Building from source rather than downloading a release binary means the workflow always tests the current generator.
+
+## Work Avoidance
+
+Because generation is deterministic, detecting "nothing changed" is a single command:
+
+```yaml
+- name: Check for changes
+  id: changes
+  run: |
+    if [ -z "$(git status --porcelain plugins/ .claude-plugin/)" ]; then
+      echo "changed=false" >> "$GITHUB_OUTPUT"
+    else
+      echo "changed=true" >> "$GITHUB_OUTPUT"
+    fi
+```
+
+A documentation change touching only prose that maps to no component produces identical skills, and the workflow exits without a commit. This is the [work avoidance](../../patterns/efficiency/work-avoidance/index.md) pattern applied to content generation.
+
+## Commit Versus Pull Request
+
+The publication path depends on why the workflow ran:
+
+| Trigger | Action | Why |
+| --- | --- | --- |
+| Release-please PR | Commit directly to the existing branch | Version sync belongs in the release PR under review |
+| Dispatch or manual | Force-push a fixed branch, open a PR if none is open | Content changes deserve independent review |
+
+Using a fixed branch for dispatch runs keeps regeneration idempotent at the PR level. Repeated documentation changes update one pull request rather than opening a queue of them.
+
+```yaml
+- name: Create pull request
+  if: steps.changes.outputs.changed == 'true' && github.event_name != 'pull_request'
+  env:
+    GH_TOKEN: ${{ steps.app-token.outputs.token }}
+  run: |
+    git push --force origin chore/regenerate-skills
+
+    if [ -z "$(gh pr list --head chore/regenerate-skills --state open --json number --jq '.[].number')" ]; then
+      gh pr create \
+        --title "chore: regenerate skills from documentation" \
+        --body "Automated regeneration. $(find plugins -name SKILL.md | wc -l) skills." \
+        --head chore/regenerate-skills \
+        --base main
+    fi
+```
+
+!!! warning "Force-Push Requires a Dedicated Branch"
+    Force-pushing is safe here only because `chore/regenerate-skills` is owned entirely by automation and reset from remote on each run. Never force-push a branch a human might have committed to.
+
+## Permissions
+
+Grant only what the job uses:
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+See [GITHUB_TOKEN Permissions](../../secure/github-actions-security/token-permissions/index.md) for least-privilege patterns.
+
+## Verification
+
+Two checks are worth running in CI, because both failure modes are silent:
+
+**Skill count did not collapse.** A parser regression can produce zero skills and still exit successfully.
+
+```bash
+count=$(find plugins -name SKILL.md | wc -l)
+[ "$count" -ge 100 ] || { echo "Skill count dropped to $count"; exit 1; }
+```
+
+**Source URLs resolve.** A URL that points at the wrong real page will not surface as a broken link.
+
+```bash
+for url in $(grep -rhoP '(?<=\[Source Documentation\]\()[^)]*' plugins/ | sort -u); do
+  path="${url#https://example.com/}"
+  [ -f "docs-src/docs/${path%/}/index.md" ] || { echo "BROKEN: $url"; exit 1; }
+done
+```
+
+!!! tip "Exit Codes Communicate Intent"
+    A generator that exits non-zero on any malformed document blocks the whole catalog over one bad page. A generator that always exits zero cannot fail CI at all. Separate the two: exit zero for per-document findings, and assert on aggregate invariants such as total count and broken links in the workflow.
+
+---
+
+**Related:** [Release Pipelines](../release-pipelines/index.md) · [Work Avoidance](../../patterns/efficiency/work-avoidance/index.md) · [GitHub Apps](../../secure/github-apps/index.md)

--- a/docs/build/documentation-as-skills/extraction-pipeline.md
+++ b/docs/build/documentation-as-skills/extraction-pipeline.md
@@ -1,0 +1,120 @@
+---
+title: Extraction Pipeline
+description: >-
+  How documents are discovered, filtered, and mapped to plugins and skill names in a documentation-to-skills generator.
+tags:
+  - automation
+  - documentation
+---
+# Extraction Pipeline
+
+Discovery, filtering, and naming. This is the stage that decides what becomes a skill and what it is called.
+
+## Discovery
+
+The generator walks a documentation root and collects candidate files from a fixed set of category directories. Each category maps one-to-one onto a plugin in the published marketplace.
+
+```bash
+skillgen \
+  --source ../adaptive-enforcement-lab-com/docs \
+  --output plugins \
+  --plugin-metadata ./plugin-metadata.json \
+  --release-manifest ./.release-please-manifest.json \
+  --templates skillgen/templates
+```
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--source` | *required* | Documentation root to scan |
+| `--output` | `./plugins` | Where generated plugin trees are written |
+| `--marketplace` | `./.claude-plugin/marketplace.json` | Marketplace catalog path |
+| `--templates` | `./templates` | Directory of Go templates |
+| `--plugin-metadata` | `./plugin-metadata.json` | Plugin descriptions, tags, shared author fields |
+| `--release-manifest` | `./.release-please-manifest.json` | Version source of truth |
+| `--verbose` | `false` | Raise log level from info to debug |
+
+Only files named `index.md` are collected. Every other markdown file is invisible to the generator and serves as supporting documentation for human readers.
+
+!!! tip "Why index.md Only"
+    Keying on `index.md` makes the directory the unit of meaning. A concept with six explanatory pages produces one skill, not six fragments. That is what an agent actually wants to load.
+
+Nesting depth is unlimited. A document six levels deep is collected on the same terms as one at the top of a category.
+
+## Filtering
+
+Two rules remove documents from the candidate set.
+
+**Blog posts are skipped.** A document is treated as a blog post when its frontmatter carries both a `date` and a non-empty `authors` list. Narrative content makes poor skill material, and this heuristic separates it without a manual exclusion list.
+
+**Documents without a title produce an error.** The skill name is derived from the title, so an empty one cannot be processed. The document is logged, counted, and skipped; generation continues.
+
+```mermaid
+graph TD
+    A[index.md found] --> B{Has date AND authors?}
+    B -->|Yes| C[Skip: blog post]
+    B -->|No| D{Has title?}
+    D -->|No| E[Error: cannot derive name]
+    D -->|Yes| F{Under a category dir?}
+    F -->|No| G[Error: unknown category]
+    F -->|Yes| H[Extract skill]
+```
+
+## Category Mapping
+
+The plugin a skill belongs to is determined by directory, not configuration. The generator scans the path for the first segment matching a known category and uses it. A document outside every category directory produces no skill.
+
+This has a consequence worth planning around: **adding a new top-level documentation section does not create a new plugin.** The category list is compiled into the generator, so a new section is invisible until that list is extended.
+
+## Skill Naming
+
+The skill name is derived from the frontmatter `title`, not the directory name. Derivation lowercases the title, replaces spaces and separators with hyphens, drops remaining non-alphanumeric characters, collapses repeated hyphens, and trims the ends.
+
+| Title | Skill name |
+| --- | --- |
+| `Idempotency` | `idempotency` |
+| `GITHUB_TOKEN Permissions Overview` | `github-token-permissions-overview` |
+| `CI/CD Integration` | `ci-cd-integration` |
+
+!!! warning "Titles Must Be Unique Within a Category"
+    Because the name comes from the title and the name becomes the output directory, two documents in the same category with identical titles silently overwrite each other. Uniqueness is a documentation convention the generator does not enforce.
+
+## Source URLs
+
+Each generated skill links back to the page it came from. Building that URL correctly requires preserving **every** path segment from the category directory down to the document's parent, then dropping the filename. MkDocs serves `index.md` as its parent directory.
+
+| Source path | Correct URL |
+| --- | --- |
+| `docs/patterns/efficiency/idempotency/index.md` | `/patterns/efficiency/idempotency/` |
+| `docs/secure/cloud-native/workload-identity/index.md` | `/secure/cloud-native/workload-identity/` |
+| `docs/enforce/index.md` | `/enforce/` |
+
+Truncating to a single segment after the category is a subtle failure. The URL still resolves to a real page, just the wrong one: the parent section rather than the document. Broken links announce themselves; wrong-but-valid links do not.
+
+!!! tip "Verify URLs Against the Filesystem"
+    A generated URL is checkable. For each emitted source URL, confirm the corresponding `index.md` exists in the documentation tree. This catches truncation, off-by-one segment errors, and stale links in a single pass.
+
+    ```bash
+    for url in $(grep -rhoP '(?<=\[Source Documentation\]\()[^)]*' plugins/ | sort -u); do
+      path="${url#https://example.com/}"
+      [ -f "docs/${path%/}/index.md" ] || echo "BROKEN: $url"
+    done
+    ```
+
+## Validation
+
+Each extracted skill is checked before it is written. Findings are advisory. The skill is written regardless, and the finding is surfaced for correction at the source document.
+
+| Check | Severity | Rationale |
+| --- | --- | --- |
+| Name present, kebab-case, within length limit | Error | The name becomes a directory; an invalid one cannot load |
+| Description present and within length limit | Error | The only field used for relevance routing |
+| Category is a known plugin | Error | Determines output location |
+| Description long enough to be distinctive | Warning | Very short descriptions rarely route well |
+| At least one section mapped to a component | Warning | Otherwise the skill body is near-empty |
+| Source URL present | Warning | The skill cannot link back to its documentation |
+
+Validate what exists at the stage you are validating. Skill body content is rendered from templates *after* extraction, so a pre-write check on rendered output reports every skill as empty. Judge the extracted sections instead.
+
+---
+
+**Next:** [Skill Anatomy](skill-anatomy.md) covers what a generated skill directory contains.

--- a/docs/build/documentation-as-skills/index.md
+++ b/docs/build/documentation-as-skills/index.md
@@ -1,0 +1,91 @@
+---
+title: Documentation as Skills
+description: >-
+  Compile MkDocs documentation into Claude Code skills so patterns reach engineers inside the agent instead of waiting to be searched for.
+tags:
+  - automation
+  - ai-agents
+  - documentation
+  - ci-cd
+---
+# Documentation as Skills
+
+Compile a documentation site into Claude Code skills, so the same markdown that renders a page also ships as a capability the agent loads at authoring time.
+
+!!! abstract "One Source, Two Delivery Mechanisms"
+
+    Documentation is **pull**. It waits to be searched for. Skills are **push**. They arrive when the agent needs them. Generating the second from the first means the two cannot drift, because they are the same artifact.
+
+## Why It Matters
+
+Engineering knowledge that lives only on a documentation site competes with whatever an AI agent produces from general training data.
+
+The agent answers in seconds without leaving the editor. The docs require someone to feel uncertain, go looking, and read. In that race, correct-but-unread documentation loses.
+
+Compiling docs into skills removes the race. The patterns are present in the agent's context when code is written, carrying the specific decisions a team has already made rather than a plausible generic default.
+
+The trade-off is that generated skills are only as good as their source. A vague page compiles into a vague skill, delivered with more authority and less friction than the page had. This pipeline is a multiplier on documentation quality, not a substitute for it.
+
+## Prerequisites
+
+- A documentation tree with consistent structure, since this pipeline keys on `index.md` files and YAML frontmatter
+- YAML frontmatter carrying at minimum `title` and `description` on every page intended to become a skill
+- Go 1.25 or later to build the generator
+- A GitHub App (or equivalent machine identity) if regeneration runs in CI and must open pull requests
+
+## Key Principles
+
+**One document, one skill.** Each `index.md` under a mapped category directory becomes exactly one skill. Sibling pages are supporting material, not separate skills. This keeps the skill count proportional to concepts rather than files.
+
+**Frontmatter is the routing contract.** The `description` field is the only text the agent sees when deciding whether a skill applies. It is copied verbatim into the generated skill, which makes it the highest-leverage field in the entire source document.
+
+**Structure carries meaning.** Section headings are matched against known component buckets: prerequisites, implementation, anti-patterns, troubleshooting. Documents written with conventional headings extract cleanly; documents with idiosyncratic ones produce thin skills.
+
+**Generation is idempotent.** Running the generator twice against unchanged docs produces byte-identical output. This makes work avoidance in CI trivial: if `git status` is clean, there is nothing to publish.
+
+**Validation is advisory, not blocking.** A skill that fails validation is still written, and the finding is surfaced. Generation of 116 good skills should not be blocked by one document with a short description.
+
+## Implementation
+
+The pipeline has four stages. Each is documented in detail on its own page.
+
+```mermaid
+graph LR
+    A[docs/**/index.md] --> B[Parse frontmatter<br/>+ sections]
+    B --> C[Map to skill<br/>components]
+    C --> D[Validate]
+    D --> E[Render SKILL.md<br/>+ side files]
+    E --> F[Write marketplace<br/>+ plugin manifests]
+```
+
+**[Extraction Pipeline](extraction-pipeline.md)**: How documents are discovered, which are skipped, and how a path becomes a plugin and skill name.
+
+**[Skill Anatomy](skill-anatomy.md)**: What a generated skill directory contains, how section mapping works, and the thresholds that decide which optional files appear.
+
+**[Marketplace and Versioning](marketplace-versioning.md)**: How plugin manifests and the marketplace catalog are generated, and how release-please drives version numbers.
+
+**[CI Automation](ci-automation.md)**: Triggering regeneration from a documentation change, authenticating with a GitHub App, and the commit-versus-PR decision.
+
+## When to Apply
+
+| Situation | Use this pattern? |
+| --- | --- |
+| Documentation already structured with consistent frontmatter | **Yes**, extraction is nearly free |
+| Patterns are team-specific and differ from general practice | **Yes**, this is the highest-value case |
+| Documentation is prose-heavy with few conventional headings | **Restructure first**, or extraction will produce thin skills |
+| Content changes several times per day | **Reconsider**, since regeneration churn may outweigh benefit |
+| Fewer than roughly ten documents | **No**, hand-author the skills instead |
+
+## Anti-Patterns
+
+**Hand-editing generated skills.** Any change to a file under the generated plugin tree is destroyed on the next run. Fix the source document instead. Marking the output directory as generated in code review tooling prevents well-meaning edits.
+
+**Skipping the description field.** A missing or vague `description` produces a skill the agent cannot route to. It will exist, consume space in the catalog, and never load.
+
+**Blocking generation on validation failure.** One malformed document should never prevent the other hundred-plus skills from publishing. Report findings, write the output, fix the source.
+
+**Treating skill count as a quality metric.** More skills is not better. Skills that never load are noise; the number worth tracking is how often each one is actually used.
+
+---
+
+**Related:** [Release Pipelines](../release-pipelines/index.md) · [Versioned Documentation](../versioned-docs/index.md) · [Go CLI Architecture](../go-cli-architecture/index.md)

--- a/docs/build/documentation-as-skills/marketplace-versioning.md
+++ b/docs/build/documentation-as-skills/marketplace-versioning.md
@@ -1,0 +1,138 @@
+---
+title: Marketplace and Versioning
+description: >-
+  Generate plugin manifests and a marketplace catalog from config, and drive versions with release-please across a multi-package repository.
+tags:
+  - ci-cd
+  - automation
+  - release
+---
+# Marketplace and Versioning
+
+How plugin manifests and the marketplace catalog are produced, and how version numbers stay consistent across independently released packages.
+
+## The Two Manifest Layers
+
+A skills marketplace has two levels of metadata:
+
+- **`marketplace.json`** is the catalog. It lists every plugin, its source directory, and its version.
+- **`plugin.json`** is written once per plugin. It carries that plugin's own name, description, version, and author fields.
+
+Both are generated. Neither is hand-edited.
+
+```mermaid
+graph TD
+    A[plugin-metadata.json] --> C[Marketplace Generator]
+    B[.release-please-manifest.json] --> C
+    C --> D[.claude-plugin/marketplace.json]
+    C --> E[plugins/patterns/.claude-plugin/plugin.json]
+    C --> F[plugins/secure/.claude-plugin/plugin.json]
+    C --> G[plugins/enforce/.claude-plugin/plugin.json]
+    C --> H[plugins/build/.claude-plugin/plugin.json]
+```
+
+## Configuration Input
+
+`plugin-metadata.json` holds everything that is not derived from documentation. It has three parts:
+
+```json
+{
+  "marketplace": {
+    "name": "example-skills",
+    "owner": { "name": "Example Org", "email": "contact@example.com" },
+    "pluginRoot": "./plugins"
+  },
+  "common": {
+    "author": { "name": "Example Org", "email": "contact@example.com" },
+    "license": "MIT",
+    "repository": "https://github.com/example-org/skills"
+  },
+  "plugins": {
+    "patterns": {
+      "description": "Reusable engineering patterns for error handling and resilience",
+      "category": "development",
+      "tags": ["patterns", "engineering"]
+    }
+  }
+}
+```
+
+The `common` block exists to avoid repeating author, license, and repository across every plugin. It is merged into each generated `plugin.json`.
+
+!!! warning "Config Is Authoritative and Destructive"
+    The catalog is rebuilt from this file on every run. A plugin absent from `plugins` is dropped from `marketplace.json`. There is no merge with the previous catalog. Anything that must persist has to be represented in config.
+
+## Versions Come From release-please
+
+Neither manifest stores a version by hand. Both read `.release-please-manifest.json`, which release-please owns:
+
+```json
+{
+  ".claude-plugin": "0.3.0",
+  "plugins/patterns": "1.0.1",
+  "plugins/secure": "1.0.1",
+  "plugins/enforce": "1.0.0",
+  "plugins/build": "1.0.0",
+  "skillgen": "1.0.1"
+}
+```
+
+The generator looks up `plugins/{name}` for each plugin and falls back to `0.0.0` with a warning when absent. The marketplace's own version comes from the `.claude-plugin` key.
+
+## Independent Package Releases
+
+Each plugin is a separately versioned release-please package, so a change confined to security documentation bumps only the `secure` plugin.
+
+```json
+{
+  "separate-pull-requests": true,
+  "packages": {
+    "skillgen": { "release-type": "go" },
+    "plugins/patterns": { "release-type": "simple" },
+    "plugins/secure": { "release-type": "simple" }
+  }
+}
+```
+
+The generator uses `go` for the CLI itself and `simple` for the plugin directories, which carry no language-specific version file.
+
+## Closing the Loop with extra-files
+
+Both release-please and the generator write versions into the same JSON files. Without coordination they would fight. The coupling mechanism is release-please's `extra-files` with JSONPath:
+
+```json
+{
+  "packages": {
+    "plugins/patterns": {
+      "release-type": "simple",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "plugins/patterns/.claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    }
+  }
+}
+```
+
+This makes `.release-please-manifest.json` the single source of truth, reached by two independent paths:
+
+1. Release-please rewrites `$.version` in each `plugin.json` when it cuts a release.
+2. The generator reads the manifest and writes the same values on regeneration.
+
+Both converge on identical output, so the order they run in does not matter.
+
+!!! tip "Determinism Enables Work Avoidance"
+    Plugin keys are sorted before serialization and JSON is written with stable indentation, so unchanged input produces byte-identical output. CI can then decide whether to publish with a single `git status --porcelain` check, with no content comparison logic.
+
+## Path Handling
+
+Output paths should be derived from flags rather than assumed relative to the working directory. A generator that hardcodes `.claude-plugin/marketplace.json` works only when invoked from the repository root. That is fine in CI and surprising locally.
+
+Passing the path explicitly makes the tool work from any directory and keeps the flag honest about what it controls.
+
+---
+
+**Next:** [CI Automation](ci-automation.md) covers triggering regeneration from documentation changes.

--- a/docs/build/documentation-as-skills/skill-anatomy.md
+++ b/docs/build/documentation-as-skills/skill-anatomy.md
@@ -1,0 +1,123 @@
+---
+title: Skill Anatomy
+description: >-
+  The structure of a generated Claude Code skill: frontmatter, section mapping, progressive disclosure, and extracted code artifacts.
+tags:
+  - documentation
+  - ai-agents
+---
+# Skill Anatomy
+
+What a generated skill directory contains, and which parts of the source document produce each file.
+
+## Directory Layout
+
+```text
+plugins/patterns/skills/idempotency/
+├── SKILL.md           # Always written
+├── examples.md        # If the source has 2+ code blocks
+├── reference.md       # If the source exceeds 200 lines
+├── troubleshooting.md # If a troubleshooting section exists
+└── scripts/
+    ├── example-1.mermaid
+    └── example-2.yaml
+```
+
+Only `SKILL.md` is guaranteed. The optional files exist to keep the always-loaded file small while making depth available when needed.
+
+!!! abstract "Progressive Disclosure"
+    `SKILL.md` is what the agent reads to decide relevance and take action. Everything else is loaded only if the task requires it. Pushing bulk into side files keeps the routing decision cheap.
+
+## Frontmatter
+
+Generated skill frontmatter carries two fields:
+
+```yaml
+---
+name: idempotency
+description: >-
+  Build automation that survives reruns. Idempotent operations let you rerun
+  workflows without fear of duplicates, corruption, or cascading failures.
+---
+```
+
+`name` comes from the derived skill name. `description` is copied **verbatim** from the source document's frontmatter. No summarization, no truncation, no fallback.
+
+!!! warning "The Description Is the Entire Routing Signal"
+    This field is the only text consulted when deciding whether a skill is relevant. A description that describes the *topic* rather than the *situation* will not route well.
+
+    Weak: `Patterns for idempotency in distributed systems.`
+
+    Strong: `Build automation that survives reruns. Use when an operation may be retried, replayed, or executed concurrently.`
+
+    Because the value is copied verbatim, improving skill routing means editing the source document's frontmatter. There is no separate place to tune it.
+
+## Section Mapping
+
+Headings in the source document are matched against component buckets using case-insensitive substring matching in both directions. Each bucket carries a keyword list.
+
+| Component | Matches headings containing |
+| --- | --- |
+| When to Use | Why It Matters, When to Use, Use Cases, What You'll Learn, Overview |
+| Prerequisites | Prerequisites, Requirements |
+| Implementation Steps | Implementation, Setup, Configuration |
+| Key Principles | Key Principles, Principles |
+| When to Apply | When to Apply, Decision |
+| Techniques | Techniques, Methods, Approaches |
+| Comparison | Comparison, Versus, Trade-offs |
+| Anti-Patterns | Anti-Patterns, Pitfalls, Mistakes |
+| Troubleshooting | Troubleshooting, Debugging |
+| Related Patterns | Related, See Also |
+
+Matching recurses into subsections. Two behaviors are worth knowing:
+
+- **When to Use falls back to the introduction.** If no heading matches, the text between the H1 and the first H2 is used instead. A strong opening paragraph is therefore load-bearing.
+- **Techniques are capped.** Only the first five technique subsections are extracted. A document with twelve produces a skill covering five.
+
+Documents written with conventional headings extract richly. Documents with idiosyncratic ones, such as "The Story So Far" or "Some Thoughts", match nothing and produce a thin skill with a warning.
+
+## Code Block Handling
+
+Fenced code blocks are extracted to `scripts/` and named by position and language: `example-1.yaml`, `example-2.sh`, `code-3.txt` when the language is unset.
+
+Blocks are also handled inline based on length:
+
+- **Ten lines or fewer**: kept inline in `SKILL.md`
+- **More than ten lines**: removed from `SKILL.md` and replaced with a pointer to `examples.md`
+
+This keeps the primary file readable while preserving every example.
+
+!!! tip "Language Tags Become File Extensions"
+    The fence language maps directly to the extension, with an unrecognized language passed through unchanged. A ` ```mermaid ` fence becomes `example-1.mermaid`. Tag fences accurately. The tag is metadata, not decoration.
+
+## Optional File Thresholds
+
+| File | Condition |
+| --- | --- |
+| `examples.md` | Source contains 2 or more fenced code blocks |
+| `reference.md` | Source exceeds 200 lines |
+| `troubleshooting.md` | A heading matches the troubleshooting bucket |
+
+`reference.md` contains the full source document with MkDocs admonitions converted to blockquotes. It is the escape hatch for cases where mapped sections lost nuance.
+
+## Admonition Conversion
+
+MkDocs admonitions are not portable markdown, so they are converted to blockquotes:
+
+```markdown
+!!! tip "Cache Aggressively"
+    Skip work when the output cannot change.
+```
+
+becomes:
+
+```markdown
+> **Cache Aggressively**
+> Skip work when the output cannot change.
+```
+
+Content is de-indented during conversion. Admonition *titles* survive as bold text, so a titled admonition carries more signal into the skill than an untitled one.
+
+---
+
+**Next:** [Marketplace and Versioning](marketplace-versioning.md) covers how manifests and versions are generated.

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -31,6 +31,8 @@ This section covers the development practices, tooling choices, and automation p
 
 **[Versioned Documentation](versioned-docs/index.md)**: Multi-version docs with Mike to prevent user confusion
 
+**[Documentation as Skills](documentation-as-skills/index.md)**: Compile documentation into Claude Code skills so patterns reach engineers inside the agent (5 pages)
+
 ## Integration with Secure and Enforce
 
 Build processes integrate with security and enforcement:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,6 +14,22 @@ Adaptive Enforcement Lab is actively building. Here's what's shipped and what's 
 
 ## Recently Shipped
 
+!!! success "Claude Code Skills Marketplace (July 2026)"
+
+    **117 skills, generated from these docs, delivered into the agent**
+
+    The documentation on this site now compiles into Claude Code skills. Same markdown source, different delivery mechanism — patterns arrive at the moment code is written instead of waiting to be searched for.
+
+    - ✅ **[claude-skills marketplace](https://github.com/adaptive-enforcement-lab/claude-skills)** - `v1.0.x`, four plugin collections
+    - ✅ **Patterns** (38 skills) - Error handling, idempotency, work avoidance, resilience, architecture
+    - ✅ **Secure** (33 skills) - GitHub Actions hardening, GKE, supply chain, OIDC federation
+    - ✅ **Enforce** (34 skills) - Kyverno, OPA, policy-as-code, SDLC hardening roadmap
+    - ✅ **Build** (12 skills) - Go CLI architecture, release pipelines, packaging, versioned docs
+    - ✅ **Automated generation** - Go extraction pipeline, clean/hexagonal architecture, release-please versioning
+    - ✅ **Continuous sync** - Skills regenerate on documentation change; source and skills cannot drift
+
+    **Story:** [The Docs Nobody Read](blog/posts/2026-07-21-docs-nobody-read.md)
+
 !!! success "Major Content Release (January 2026)"
 
     **Comprehensive Security & DevOps Content Pipeline**
@@ -99,15 +115,11 @@ Adaptive Enforcement Lab is actively building. Here's what's shipped and what's 
 
 ## In Progress
 
-!!! info "Claude Code Skills Marketplace"
+!!! info "Skills Marketplace Documentation"
 
-    Building automated skill generation pipeline to package AEL patterns as reusable Claude Code skills:
-
-    - 🔄 Automated skill generator from pattern articles (#194, #198)
-    - 🔄 Multi-skill marketplace structure (#195)
-    - 🔄 Pattern-based skills: Fail Fast, Prerequisite Checks, Idempotency, Work Avoidance
-    - 🔄 Enforcement skills: Pre-commit hooks, policy-as-code, CI gates
-    - 🔄 Build skills: Release pipelines, versioned docs, CLI architecture
+    - ✅ **[Documentation as Skills](build/documentation-as-skills/index.md)** - Extraction pipeline, skill anatomy, marketplace versioning, CI automation
+    - 🔄 Installation and team distribution guide
+    - 🔄 Usage telemetry: which skills actually load
 
 !!! info "Community Hub"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -416,6 +416,12 @@ nav:
           - Change Detection: build/release-pipelines/change-detection.md
           - Workflow Triggers: build/release-pipelines/workflow-triggers.md
           - Protected Branches: build/release-pipelines/protected-branches.md
+      - Documentation as Skills:
+          - build/documentation-as-skills/index.md
+          - Extraction Pipeline: build/documentation-as-skills/extraction-pipeline.md
+          - Skill Anatomy: build/documentation-as-skills/skill-anatomy.md
+          - Marketplace & Versioning: build/documentation-as-skills/marketplace-versioning.md
+          - CI Automation: build/documentation-as-skills/ci-automation.md
       - Versioned Docs:
           - build/versioned-docs/index.md
           - Mike Configuration: build/versioned-docs/mike-configuration.md


### PR DESCRIPTION
## What

Three related changes covering the Claude Code skills marketplace, which shipped in January 2026 but was never documented on the site.

### 1. New section: Documentation as Skills

`docs/build/documentation-as-skills/` — five pages under **Build**:

| Page | Covers |
| --- | --- |
| Index | Why, when to apply, key principles, anti-patterns |
| Extraction Pipeline | Discovery, filtering, category mapping, naming, source URLs, validation |
| Skill Anatomy | Frontmatter, section mapping, progressive disclosure, code extraction |
| Marketplace & Versioning | Plugin manifests, release-please coupling via `extra-files` |
| CI Automation | Cross-repo triggers, GitHub App auth, work avoidance, commit-vs-PR |

The index compiles into a skill itself, so it is written to extract cleanly against the same section-mapping rules it documents.

### 2. Blog post: The Docs Nobody Read

First post since **2026-01-07** — a 195-day gap. Narrative, not instructional: why a finished documentation site still failed to reach engineers, and the shift to delivering the same content where the work now happens. Links out to the section above for implementation detail.

### 3. Roadmap correction

The roadmap listed the marketplace as **in progress** despite `v1.0.0` shipping on 2026-01-05, and pointed at issues `#194`, `#195`, `#198` — **none of which exist in this repository**. Both problems were visible on a public page for six months.

Moved to shipped with real counts (38 patterns / 34 enforce / 33 secure / 12 build), dead references replaced with genuinely outstanding work.

## Why it matters

117 skills were shipping to users with zero documentation on the site that generates them, while the roadmap advertised the work as unfinished.

## Verification

- `mkdocs build --strict` exits 0
- All six pre-commit hooks pass: markdownlint, readability, forbidden-tech, description frontmatter, title frontmatter, mkdocs build
- Every cross-link target verified to exist before commit
- Blog post: description 117 chars (under 160), `<!-- more -->` present, no admonitions above the fold

## Notes

- Pairs with adaptive-enforcement-lab/claude-skills#61, which fixes generator defects found while researching this content. That PR's fixes are what these pages document, so this describes actual behaviour rather than intended behaviour.
- The readability hook rejected the first drafts for mid-sentence dash density. Prose was restructured rather than the threshold relaxed.
- Related issues: none open. The roadmap's references were dangling.

## Checklist

- [x] Clear, descriptive title
- [x] One logical change per PR (documenting the marketplace)
- [x] `mkdocs build` succeeds
- [x] Blog post follows the CONTRIBUTING frontmatter and RSS conventions
- [x] Mermaid diagrams included where they clarify flow