### PR TITLE
chore: consolidate renovate dependency updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -27,7 +27,7 @@ jobs:
       workflows_changed: ${{ steps.changes.outputs.workflows_any_changed }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Analyze documentation
         uses: adaptive-enforcement-lab/readability@v3.0.2

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Analyze documentation
-        uses: adaptive-enforcement-lab/readability@v3.0.2
+        uses: adaptive-enforcement-lab/readability@v3.1.0
         with:
           path: docs/
           check: ${{ inputs.fail_on_threshold }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
           fetch-depth: 0  # Full history for RSS plugin dates
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
           owner: adaptive-enforcement-lab
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
         run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
 
       - name: Cache MkDocs Material
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: ~/.cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Full history for RSS plugin dates
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         files: \.md$
         exclude: ^(CHANGELOG\.md|\.content-machine/.*|docs/includes/.*)$
   - repo: https://github.com/adaptive-enforcement-lab/readability
-    rev: v3.0.1
+    rev: v3.1.0
     hooks:
       - id: readability-docs
         name: check documentation readability

--- a/docs/secure/scorecard/checks/code-review/part-2.md
+++ b/docs/secure/scorecard/checks/code-review/part-2.md
@@ -1,5 +1,7 @@
 ---
 title: Contributors Check
+description: >-
+  Raise the OpenSSF Scorecard Contributors score by attracting diverse contributors and reducing single-maintainer risk across your project.
 ---
 # Contributors Check
 

--- a/docs/secure/scorecard/score-progression/tier-1.md
+++ b/docs/secure/scorecard/score-progression/tier-1.md
@@ -1,5 +1,7 @@
 ---
 title: Tier 1
+description: >-
+  Quick-win OpenSSF Scorecard fixes that raise your rating with minimal effort, covering branch protection, security policy, and dependency pinning.
 ---
 # Tier 1
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "pre-commit": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
## What

Consolidates all five open Renovate branches into one PR, plus two fixes surfaced while validating them.

### Dependency updates

| Action | From | To | Supersedes |
| --- | --- | --- | --- |
| `actions/cache` | v5 | v6 | #254 |
| `actions/checkout` | v6 | v7 | #253 |
| `actions/setup-python` | v6 | v7 | #255 |
| `adaptive-enforcement-lab/readability` | v3.0.2 | v3.1.0 | #252 |
| `googleapis/release-please-action` | v4 | v5 | #251 |

All five merged with **zero conflicts**. Net change: 9 lines across 4 workflow files.

### Version drift fix

The readability **action** moves to v3.1.0, but the **pre-commit hook** was pinned at v3.0.1 — so local runs and CI would lint with different versions of the same tool.

Root cause: `config:recommended` leaves Renovate's `pre-commit` manager disabled, so the hook rev never tracked the action. Aligned the rev and enabled the manager so it cannot drift again.

### Pre-existing frontmatter gaps

Two pages had no `description` frontmatter, which blocked `check-description` from passing across the full tree:

- `docs/secure/scorecard/checks/code-review/part-2.md`
- `docs/secure/scorecard/score-progression/tier-1.md`

Both predate this branch and are unrelated to the bumps, but with them fixed `pre-commit run --all-files` now passes cleanly for the first time.

## Verification

```
pre-commit run --all-files
  markdownlint ........................ Passed
  check documentation readability ..... Passed   (v3.1.0)
  block forbidden technologies ........ Passed
  check description frontmatter ....... Passed
  check title frontmatter ............. Passed
  mkdocs build ........................ Passed

mkdocs build --strict   # exit 0
```

The readability hook was re-run against the entire tree under the **new** v3.1.0 to confirm the upgrade introduces no regressions.

No dependency manifests changed — `requirements.txt` is unpinned and these are all GitHub Actions bumps, so no lockfile regeneration was needed.

## Not addressed here

**Actions are pinned to tags, not SHAs.** All 9 references use `@v6`/`@v7` rather than commit SHAs, which contradicts this project's own [action pinning guidance](https://adaptive-enforcement-lab.com/secure/github-actions-security/action-pinning/). That is pre-existing across every workflow and worth its own PR — folding a pinning migration into a version bump would make both harder to review and to revert.

## Notes

- The five superseded Renovate PRs will close automatically when this merges. Their branches are left intact for Renovate to manage.
- No force-push. Branch is a clean fast-forward from `main`.

## Checklist

- [x] All renovate branches merged, no conflicts
- [x] Pre-commit hooks pass on `--all-files`
- [x] `mkdocs build --strict` succeeds
- [x] No unresolved import, type, or build errors
- [x] One logical change per PR (dependency consolidation)