### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,15 @@
   ],
   "pre-commit": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Pin GitHub Actions to commit SHAs while keeping readable semver updates",
+      "extends": [
+        "helpers:pinGitHubActionDigests"
+      ],
+      "extractVersion": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$",
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+    }
+  ]
 }


### PR DESCRIPTION
## What

Enables Renovate's native SHA pinning. No workflow files change here — Renovate raises the actual pinning PR itself once this merges.

```json
{
  "extends": ["helpers:pinGitHubActionDigests"],
  "extractVersion": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$",
  "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
}
```

Actions become:

```yaml
- uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
```

## Why the extra rules matter

`helpers:pinGitHubActionDigests` alone produces **digest** updates: PRs that bump an opaque SHA with no semantic meaning. The paired `extractVersion` and `versioning` rules teach Renovate to read the trailing comment as the real version, so updates keep arriving as readable "update actions/checkout to v7" PRs.

Grouping, scheduling, changelogs and automerge behaviour are all preserved. The only change is that a moved tag can no longer silently alter what runs in CI.

## Context

PR #258 bumped five actions and I flagged there that all references were tag-pinned rather than SHA-pinned, contradicting this project's own [action pinning guidance](https://adaptive-enforcement-lab.com/secure/github-actions-security/action-pinning/) — guidance that also ships as the `secure:action-pinning-overview` skill. This closes that gap at the configuration level rather than by hand-editing workflows, so Renovate stays the owner of those references.

## Verification

```
renovate-config-validator renovate.json
 INFO: Validating renovate.json
 INFO: Config validated successfully
```

## Expected follow-up

Renovate opens a pinning PR converting every tag reference to a SHA. That diff is large but entirely mechanical, and keeping it separate from this behavioural change is deliberate.

## Checklist

- [x] Clear, descriptive title
- [x] One logical change per PR
- [x] Config validated with the official validator