### PR TITLE
docs: update alpine base images and Go version references

### DIFF
--- a/docs/build/documentation-as-skills/ci-automation.md
+++ b/docs/build/documentation-as-skills/ci-automation.md
@@ -91,7 +91,7 @@ Both repositories are checked out, the generator is built from source, and it ru
 
 - uses: actions/setup-go@v6
   with:
-    go-version: '1.25'
+    go-version: '1.26'
 
 - run: go build -o ../bin/skillgen ./cmd/skillgen
   working-directory: skillgen

--- a/docs/build/documentation-as-skills/index.md
+++ b/docs/build/documentation-as-skills/index.md
@@ -30,7 +30,7 @@ The trade-off is that generated skills are only as good as their source. A vague
 
 - A documentation tree with consistent structure, since this pipeline keys on `index.md` files and YAML frontmatter
 - YAML frontmatter carrying at minimum `title` and `description` on every page intended to become a skill
-- Go 1.25 or later to build the generator
+- Go 1.26 or later to build the generator
 - A GitHub App (or equivalent machine identity) if regeneration runs in CI and must open pull requests
 
 ## Key Principles

--- a/docs/enforce/policy-as-code/index.md
+++ b/docs/enforce/policy-as-code/index.md
@@ -90,7 +90,7 @@ The policy-platform container aggregates policies from multiple sources:
 FROM security-policy-repo:main AS security_policy_repo
 FROM devops-policy-repo:main AS devops_policy_repo
 
-FROM alpine:3.22
+FROM alpine:3.24
 RUN apk add helm kyverno pluto spectral
 
 COPY --from=security_policy_repo /repos/security-policy/ /repos/security-policy/

--- a/docs/enforce/policy-as-code/local-development/index.md
+++ b/docs/enforce/policy-as-code/local-development/index.md
@@ -34,7 +34,7 @@ FROM security-policy-repo:main AS security_policy_repo
 FROM devops-policy-repo:main AS devops_policy_repo
 
 # Alpine base with all tools
-FROM alpine:3.22
+FROM alpine:3.24
 RUN apk add curl bash ca-certificates git helm yq
 
 # Install Kyverno CLI

--- a/docs/enforce/policy-as-code/multi-source-policies/index.md
+++ b/docs/enforce/policy-as-code/multi-source-policies/index.md
@@ -77,7 +77,7 @@ FROM europe-west6-docker.pkg.dev/ops/charts/security-policy-repo:main AS securit
 FROM europe-west6-docker.pkg.dev/ops/charts/backend-applications-repo:main AS backend_applications_repo
 
 # Final stage: Combine everything
-FROM alpine:3.22.1
+FROM alpine:3.24.1
 
 # Install policy tools
 RUN apk add --no-cache \

--- a/docs/enforce/policy-as-code/policy-packaging/distribution.md
+++ b/docs/enforce/policy-as-code/policy-packaging/distribution.md
@@ -86,11 +86,11 @@ docker run --rm -v $(pwd):/workspace policy-platform:latest bash -c '\
 
 ```dockerfile
 # Build tools in separate stages
-FROM alpine:3.22.1 AS builder
+FROM alpine:3.24.1 AS builder
 RUN apk add build-base
 
 # Final image only has binaries
-FROM alpine:3.22.1
+FROM alpine:3.24.1
 COPY --from=builder /usr/local/bin/kyverno /usr/local/bin/
 ```
 

--- a/docs/enforce/policy-as-code/policy-packaging/index.md
+++ b/docs/enforce/policy-as-code/policy-packaging/index.md
@@ -31,7 +31,7 @@ FROM policy-repo-2:tag AS policy_repo_2
 FROM policy-repo-3:tag AS policy_repo_3
 
 # Final stage: Aggregate and install tools
-FROM alpine:3.22.1
+FROM alpine:3.24.1
 
 # Install tools
 RUN apk add curl bash helm yq

--- a/docs/enforce/policy-as-code/policy-packaging/maintenance.md
+++ b/docs/enforce/policy-as-code/policy-packaging/maintenance.md
@@ -64,7 +64,7 @@ tests/
 **Tools**:
 
 ```dockerfile
-FROM alpine:3.22.1  # Not :latest
+FROM alpine:3.24.1  # Not :latest
 RUN curl ...v1.13.2/kyverno...  # Not /latest/
 ```
 


### PR DESCRIPTION
## What

Two version updates applied at their **source**, where the generated copies downstream cannot revert them.

### Alpine 3.22 → 3.24

| File | Change |
| --- | --- |
| `enforce/policy-as-code/index.md` | `3.22` → `3.24` |
| `enforce/policy-as-code/local-development/index.md` | `3.22` → `3.24` |
| `enforce/policy-as-code/multi-source-policies/index.md` | `3.22.1` → `3.24.1` |
| `enforce/policy-as-code/policy-packaging/index.md` | `3.22.1` → `3.24.1` |
| `enforce/policy-as-code/policy-packaging/maintenance.md` | `3.22.1` → `3.24.1` |
| `enforce/policy-as-code/policy-packaging/distribution.md` | `3.22.1` → `3.24.1` (×2) |

**Why here and not in claude-skills.** Renovate opened `renovate/alpine-3.x` against that repository, editing four generated Dockerfiles under `plugins/`. Those files are produced by `skillgen` from these pages, and `CONTRIBUTING.md` states they must never be hand-edited — the next regeneration would revert the bump.

Fixing the source means the change flows through regeneration and actually sticks. A companion PR adds `ignorePaths` for `plugins/` so Renovate stops raising PRs there.

**Deliberately left alone:** `template-library/kyverno/image/security.md` stays at `alpine:3.19`. That example illustrates a fixed approved-base-image record with hardcoded 2024 labels and timestamps. It documents a point-in-time artifact, not a live dependency.

### Go 1.25 → 1.26

The `documentation-as-skills` pages stated Go 1.25 as a prerequisite and in the CI example. The generator repository is moving to 1.26, so these are aligned to match reality rather than describe a stale requirement.

## Verification

```
pre-commit run --files <changed>
  markdownlint ........................ Passed
  check documentation readability ..... Passed
  block forbidden technologies ........ Passed
  check description frontmatter ....... Passed
  check title frontmatter ............. Passed
  mkdocs build ........................ Passed

mkdocs build --strict   # exit 0
```

Latest alpine confirmed as 3.24.1 against the Docker Hub tag list; latest Go confirmed as 1.26.5 against the official release endpoint.

## Related

- adaptive-enforcement-lab/claude-skills#69 — Go 1.26 and dependency consolidation
- adaptive-enforcement-lab/claude-skills#70 — `ignorePaths` for generated content

## Checklist

- [x] Clear, descriptive title
- [x] One logical change per PR (version currency at source)
- [x] `mkdocs build` succeeds