### PR TITLE
chore: detect container images in policy-as-code documentation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,19 @@
   "pre-commit": {
     "enabled": true
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Detect container images in Dockerfile examples embedded in policy-as-code documentation. These fenced blocks are extracted into real .dockerfile files by skillgen, so they are genuine dependencies despite living inside markdown.",
+      "managerFilePatterns": [
+        "/^docs/enforce/policy-as-code/.*\\.md$/"
+      ],
+      "matchStrings": [
+        "FROM\\s+(?<depName>[a-z0-9][a-z0-9._/-]*):(?<currentValue>[\\w][\\w.-]*)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "description": "Pin GitHub Actions to commit SHAs while keeping readable semver updates",
@@ -14,6 +27,34 @@
       ],
       "extractVersion": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$",
       "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+    },
+    {
+      "description": "template-library examples deliberately reference deprecated images to demonstrate what policies block",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        "docs/enforce/policy-as-code/template-library/**"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Placeholder image names used to illustrate multi-source policy layering. They do not resolve to real registries.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "backend-applications-repo",
+        "devops-policy-repo",
+        "policy-repo-1",
+        "policy-repo-2",
+        "policy-repo-3",
+        "security-policy-repo",
+        "europe-west6-docker.pkg.dev/ops/charts/backend-applications-repo",
+        "europe-west6-docker.pkg.dev/ops/charts/devops-policy-repo",
+        "europe-west6-docker.pkg.dev/ops/charts/security-policy-repo"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## The problem

Renovate has **never** been able to see the alpine base images in this repository. Confirmed: zero alpine or docker PRs have ever been opened here.

The reason is file extension. Renovate's Dockerfile manager matches:

```
/(^|/|\.)([Dd]ocker|[Cc]ontainer)file$/
/(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$/
```

| Where the image reference lives | Detected? |
| --- | --- |
| ```` ```dockerfile ```` fence inside `docs/**/*.md` | **No** — no manager scans markdown |
| `scripts/example-1.dockerfile` in claude-skills | **Yes** — `.dockerfile` matches the first pattern |

`skillgen` extracts those fences into real `.dockerfile` files, which accidentally made the generator this project's only container-image scanner — pointed at **generated output**, where `CONTRIBUTING.md` forbids edits and regeneration reverts them.

The consequence was not theoretical. `renovate/alpine-3.x` was raised against claude-skills, **autoclosed**, and its branch deleted. The generated files still read `alpine:3.22`. The dependency was stuck while appearing managed.

## The fix

A custom regex manager scoped to `docs/enforce/policy-as-code`, with two deliberate carve-outs.

**Excluded — `template-library/`.** Those examples reference deprecated images *on purpose*, to demonstrate what the policies block. Bumping `alpine:3.19` there would destroy the lesson.

**Suppressed — placeholder images.** `policy-repo-1:tag`, `security-policy-repo:main` and the internal registry paths illustrate multi-source layering and resolve to nothing real.

## Verification

Every `FROM` line in scope was run through the actual configured regex, with file paths, honouring both carve-outs:

```
=== WOULD OPEN PRs FOR ===
   alpine:3.24
   alpine:3.24.1
=== EXCLUDED: template-library (didactic) ===
   alpine:3.19                               <- template-library/kyverno/image/security.md
   gcr.io/distroless/static-debian12:latest  <- template-library/opa/image/base.md
   golang:1.21                               <- template-library/opa/image/base.md
=== SUPPRESSED: placeholder images ===
   11 entries
```

Correctly ignored by the pattern: `FROM scratch`, `FROM runtime`, and untagged `FROM gcr.io/distroless/static-debian12 AS runtime`.

Config validated:

```
npx --package renovate@latest renovate-config-validator
 INFO: Config validated successfully against 1 file(s)
```

A note on that: a stale `npx` cache initially resolved Renovate 37, which rejected `managerFilePatterns` — that field was introduced in v41. This repository uses the **hosted Renovate App** (`app/renovate`), which always runs current, so `managerFilePatterns` is correct. Worth knowing if anyone validates locally and hits the same error.

## Scope

Intentionally narrow. A repo-wide `docs/**/*.md` pattern would sweep in ~48 `FROM` lines, many of them frozen illustrations — `ubuntu:20.04`/`22.04`/`24.04` shown together to demonstrate version pinning, allowlists that name deprecated images as things to reject. Renovate would "helpfully" bump examples whose entire point is being outdated.

Widening this later is a deliberate decision, not a default.

## Related

- adaptive-enforcement-lab/claude-skills#70 — `ignorePaths` for `plugins/`, the other half of this fix
- #261 — the alpine bump this makes maintainable

## Checklist

- [x] Clear, descriptive title
- [x] One logical change per PR
- [x] Config validated with the official validator
- [x] Regex tested against real repository content, not assumed