### PR TITLE
ci: dispatch docs-updated to claude-skills after a successful deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,10 +157,32 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
 
+  notify-claude-skills:
+    name: Notify claude-skills
+    needs: [deploy-docs]
+    if: always() && !cancelled() && needs.deploy-docs.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # 3.2.0
+        with:
+          app-id: ${{ secrets.CORE_APP_ID }}
+          private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
+          owner: adaptive-enforcement-lab
+
+      - name: Dispatch docs-updated to claude-skills
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/adaptive-enforcement-lab/claude-skills/dispatches \
+            --method POST \
+            -f event_type=docs-updated
+
   release-status:
     name: Release Status
     runs-on: ubuntu-latest
-    needs: [release-please, detect-changes, analyze-docs, build-docs, deploy-docs]
+    needs: [release-please, detect-changes, analyze-docs, build-docs, deploy-docs, notify-claude-skills]
     if: always()
     steps:
       - name: Check release results
@@ -173,6 +195,7 @@ jobs:
           echo "| Doc Analysis | ${{ needs.detect-changes.outputs.docs_changed }} | ${{ needs.analyze-docs.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Build Docs | ${{ needs.detect-changes.outputs.docs_changed }} | ${{ needs.build-docs.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Deploy | - | ${{ needs.deploy-docs.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Notify claude-skills | - | ${{ needs.notify-claude-skills.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if any required job failed
         if: |


### PR DESCRIPTION
## Summary
- `claude-skills`' `generate-skills.yml` already accepts a `repository_dispatch` `docs-updated` event to trigger skill regeneration, but nothing in this repo ever sent it. Skill regeneration in claude-skills currently only ran on manual `workflow_dispatch` or piggybacked on a release-please PR — docs changes never triggered it.
- Adds a `notify-claude-skills` job to `release.yml`, gated on `deploy-docs` succeeding, that POSTs to `repos/adaptive-enforcement-lab/claude-skills/dispatches` with `event_type=docs-updated`.
- Uses the same `CORE_APP` GitHub App token already used elsewhere to checkout/push into `claude-skills` from this repo's workflows, so no new secret or permission is needed.
- `ci:` type is hidden in this repo's `release-please-config.json`, so this lands without cutting a release.
- Dispatch failure is not wired into the "fail if any required job failed" gate — it's a downstream notification, not a docs-release blocker.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — valid YAML
- [x] Pre-commit hooks (markdownlint, readability, forbidden-tech check, `mkdocs build`) passed
- [ ] After merge: confirm the next docs deploy fires a `generate-skills.yml` run in claude-skills via `repository_dispatch`