### PR TITLE
docs: add governance patterns index linking existing security docs

### DIFF
--- a/docs/patterns/governance/index.md
+++ b/docs/patterns/governance/index.md
@@ -1,0 +1,64 @@
+---
+title: Governance Patterns
+tags:
+  - governance
+  - security
+  - compliance
+  - patterns
+description: >-
+  Vendor-neutral governance patterns for audit logging, credential rotation, and least privilege access control, each linked to a concrete implementation guide.
+---
+# Governance Patterns
+
+Governance patterns enforce accountability over who can act, what they are allowed to do, and what record exists once they have acted.
+They are vendor-neutral by design.
+The underlying platform, whether a managed cloud, a self-hosted cluster, or a hybrid estate, changes which service produces the logs or issues the credentials.
+The pattern itself does not change.
+
+This page frames three governance patterns as a single family: audit logging, credential rotation, and least privilege.
+Each section below states the principle in vendor-neutral terms, then links to a concrete page on this site that shows the principle implemented against a specific platform.
+
+!!! note "Why this page links out instead of duplicating"
+    The implementation detail for each pattern already exists elsewhere on this site, written against a specific platform.
+    This page does not repeat that detail. It names the shared principle once and points to the concrete page for the how-to.
+
+## Audit Logging
+
+Every privileged action must produce an immutable, attributable record, whether it changes infrastructure, reads a secret, or modifies access control.
+The record needs an actor, a timestamp, and the action taken.
+It also needs to live somewhere the actor who performed the action cannot alter or delete it.
+Without that record, an incident response team reconstructs events from memory instead of evidence.
+
+The pattern holds regardless of which logging backend collects the events.
+What matters is that the sink is append-only or write-once, that it captures both control-plane and data-plane operations, and that retention covers the compliance window that applies to the workload.
+
+See it applied to a managed Kubernetes control plane: [Audit Logging](../../secure/cloud-native/gke-hardening/iam-configuration/audit-logging.md).
+
+## Credential Rotation
+
+Credentials lose their trustworthiness the longer they remain unrotated.
+A long-lived key that leaks grants an attacker indefinite access.
+A key that rotates on a fixed schedule bounds the damage to a known window.
+Rotation is not a one-time hygiene task.
+It is a scheduled, automated process with a defined cadence, a validation step that confirms the new credential works before the old one is revoked, and a rollback path if it does not.
+
+The pattern applies to any credential type: API keys, service account keys, signing certificates, or app-specific private keys.
+The rotation mechanism differs by platform, but the requirement, automated rotation on a fixed schedule with verified cutover, does not.
+
+See it applied to GitHub App private keys: [Credential Rotation and Security](../../secure/github-apps/storing-credentials/rotation-security.md).
+
+## Least Privilege
+
+Access should be scoped to exactly what a task requires, nothing more.
+Every permission granted beyond that scope is unmeasured risk sitting idle until it is either misused or exploited.
+Least privilege is enforced by granting fine-grained roles instead of broad administrative ones, by scoping permissions to the smallest resource boundary available, and by treating any wildcard or catch-all grant as a finding, not a convenience.
+
+The pattern is identical across identity systems.
+Define the minimal role for each actor class, bind it narrowly, and review the bindings on a schedule rather than assuming they stay correct forever.
+
+See it applied to IAM roles on a managed Kubernetes cluster: [Least Privilege Roles](../../secure/cloud-native/gke-hardening/iam-configuration/least-privilege-roles.md).
+
+## Related Content
+
+- [Secure-by-Design Pattern Library](../security/secure-by-design/index.md): Zero trust, defense in depth, least privilege, and fail secure at the architecture layer
+- [The Last Service Account Key](../../blog/posts/2026-01-05-last-service-account-key.md): The incident that motivated these three patterns

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1088,6 +1088,8 @@ nav:
               - Least Privilege: patterns/security/secure-by-design/least-privilege.md
               - Fail Secure: patterns/security/secure-by-design/fail-secure.md
               - End-to-End Integration: patterns/security/secure-by-design/integration.md
+      - Governance:
+          - patterns/governance/index.md
       - Authoritative Architectural Documentation and Data Contracts: patterns/authoritative-architectural-documentation-and-data-contracts/index.md
   - Roadmap: roadmap.md
   - Tags: tags.md


### PR DESCRIPTION
## Summary

Closes #238, #239, #240

Issues #238, #239, #240 each requested a new standalone pattern doc (least privilege, credential rotation, audit logging) as "Referenced By" follow-ups from the blog post `docs/blog/posts/2026-01-05-last-service-account-key.md`. That blog post already links to concrete implementation pages for all three:

- Least privilege → `docs/secure/cloud-native/gke-hardening/iam-configuration/least-privilege-roles.md`
- Credential rotation → `docs/secure/github-apps/storing-credentials/rotation-security.md`
- Audit logging → `docs/secure/cloud-native/gke-hardening/iam-configuration/audit-logging.md`

Rather than duplicate that content at three new paths, this PR adds a single cross-cutting index, `docs/patterns/governance/index.md`, that frames these three as one vendor-neutral "Governance" pattern family (in the same style as `docs/patterns/security/secure-by-design/index.md`) and links out to the three existing pages above as the concrete "how this applies in practice" reference.

## Changes

- Add `docs/patterns/governance/index.md`
- Add "Governance" to the Patterns nav in `mkdocs.yml`, alongside "Security"

## Test plan

- [x] `pre-commit run --files docs/patterns/governance/index.md mkdocs.yml` passes (markdownlint, readability, forbidden-tech, title, description, mkdocs build)
- [x] `mkdocs build --strict` passes with no nav or link errors