### PR TITLE
docs: add code examples and cross-link to consolidating dependency updates article

### DIFF
--- a/docs/build/consolidating-automated-dependency-updates/index.md
+++ b/docs/build/consolidating-automated-dependency-updates/index.md
@@ -1,12 +1,9 @@
 ---
 title: Consolidating Automated Dependency Updates
 description: >-
-  This guide outlines strategies for merging multiple automated dependency updates into a single change stream,
-  detailing how to resolve common conflicts and ensure a consistent dependency graph.
+  Merge automated dependency update PRs into a single change stream. Resolve conflicts and keep the dependency graph consistent.
 ---
-Strategically consolidating multiple automated dependency updates into a single change stream is crucial for managing project health, reducing CI/CD churn, and ensuring a stable dependency graph.
-This practice helps to streamline the review process and minimize the overhead associated with numerous small,
-independent updates.
+Dependency bots open a lot of small pull requests. Left unchecked, they flood CI/CD with individual runs and stack merge conflicts onto shared manifest files. Consolidating multiple updates into one change stream cuts that churn, speeds up review, and keeps the dependency graph stable.
 
 !!! warning "Beware of Blind Merges"
     Merging multiple dependency update branches without thorough conflict resolution or testing can introduce subtle breaking changes or unintended version regressions, leading to build failures or runtime errors. Always validate the consolidated state.
@@ -21,7 +18,7 @@ Automated dependency management systems frequently propose individual updates fo
 
 ### Strategies for Consolidation
 
-Effective consolidation involves combining several pending updates into a single, comprehensive change.
+Effective consolidation combines several pending updates into one comprehensive change.
 
 #### Batching Policies
 
@@ -33,9 +30,48 @@ Instead of processing every automated update individually, consider policies for
 | **Major/Minor/Patch** | Batch updates based on update type or impact. | Managing risk exposure, easier review of breaking changes.              |
 | **Ecosystem-Specific** | Group updates for a particular dependency management tool or system.                                         | Targeted testing, simplifying validation for specific components.       |
 
+Renovate and Dependabot both support native grouping. Configure the bot to open one PR per batch instead of one per dependency:
+
+```json5 title="renovate.json5"
+{
+  extends: ["config:recommended"],
+  packageRules: [
+    {
+      // Batch every non-breaking update into a single weekly PR
+      groupName: "all non-major dependencies",
+      matchUpdateTypes: ["minor", "patch"],
+      schedule: ["before 6am on monday"],
+    },
+    {
+      // Keep one ecosystem isolated for targeted testing
+      groupName: "go dependencies",
+      matchManagers: ["gomod"],
+      groupSlug: "go-deps",
+    },
+  ],
+  prConcurrentLimit: 5,
+  prHourlyLimit: 2,
+}
+```
+
+Dependabot's equivalent lives in `dependabot.yml`, using `groups` instead of `packageRules`:
+
+```yaml title=".github/dependabot.yml"
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+```
+
 #### Manual Consolidation Workflow
 
-When an automated system doesn't provide adequate batching, a manual workflow can be implemented:
+When an automated system doesn't batch well enough, run a manual workflow:
 
 1.  **Identify Candidates:** Review pending automated dependency update branches.
 2.  **Establish a Base Branch:** Create a new feature branch from your main development branch.
@@ -53,21 +89,44 @@ Conflicts in dependency manifests are common. A systematic approach is vital.
 
 When multiple updates suggest different versions for the same dependency, establish a clear prioritization rule:
 
-*   **Highest Version First:** A common and often robust strategy is to accept the highest proposed version across all conflicting updates. This ensures the codebase benefits from the latest fixes and features.
+*   **Highest Version First:** Accept the highest proposed version across all conflicting updates. This keeps the codebase on the latest fixes and features.
 *   **Stable Version Preference:** For critical dependencies, prefer the most stable version, even if a higher, less tested version is available.
 *   **Explicit Override:** In complex scenarios, manually specify the desired version based on project requirements or known compatibility.
 
 #### Tool-Assisted Resolution
 
-After combining changes, leverage language-specific tools to validate and resolve the dependency graph:
+After combining changes, run the ecosystem's own tooling to regenerate lock files and validate the graph. For a Go project merging several update branches into one consolidation branch:
 
-*   For Go projects, `go mod tidy` is essential for cleaning up unused dependencies and adding missing ones, ensuring the `go.sum` file accurately reflects the `go.mod` state.
-*   For other project types, utilize their respective package managers or build tools to update lock files and validate dependencies.
+```bash
+# Merge each pending update branch into the consolidation branch
+git checkout consolidate/deps-2026-08-22
+git merge --no-ff renovate/go-mod-updates
+
+# go.mod/go.sum conflicts don't resolve cleanly by hand;
+# regenerate them from the merged require directives instead
+go mod tidy
+go mod verify
+
+# Confirm the resolved graph actually builds and passes tests
+go build ./...
+go test ./...
+
+git add go.mod go.sum
+git commit -m "chore: resolve dependency conflicts after consolidation"
+```
+
+The same pattern applies to other ecosystems: `npm install` (or `npm ci` against a merged `package.json`) regenerates `package-lock.json`, and `mvn dependency:tree` surfaces conflicting transitive versions in a Maven project before you run the build.
 
 ### Maintaining a Consistent Dependency Graph
 
 After consolidation, verify the integrity of your dependency graph.
 
 1.  **Re-evaluate Transitive Dependencies:** Ensure that accepting a new direct dependency version doesn't inadvertently introduce incompatible transitive dependencies.
-2.  **Full Build and Test Cycle:** Run a comprehensive build and testing cycle to catch any regressions or unexpected behavior resulting from the consolidated updates.
-3.  **Static Analysis and Linting:** Apply static analysis or linting to identify any potential code changes required due to updated dependencies.
+2.  **Full Build and Test Cycle:** Run the full build and test suite to catch regressions from the consolidated updates.
+3.  **Static Analysis and Linting:** Run static analysis and linting to catch code changes the updated dependencies require.
+
+---
+
+## See Also
+
+*   [Change Detection](../release-pipelines/change-detection.md): Dependency-update PRs are exactly the kind of change that triggers (or should skip) cascade rebuilds. Map manifest files into your change-detection categories so a consolidated update PR only rebuilds what it actually touches.


### PR DESCRIPTION
## Summary

- Add a Renovate grouping/batching config example (`renovate.json5`) and the Dependabot `groups` equivalent, so the article has real fenced code instead of only inline code spans.
- Add a `go mod tidy`/conflict-resolution command block covering merging update branches into a consolidation branch, with npm/Maven equivalents noted.
- Tighten passive/filler prose in the intro and several bullet points.
- Trim the frontmatter `description` from 193 to 126 characters.
- Add a "See Also" cross-link to the Change Detection page, since dependency-update PRs are exactly the kind of change that interacts with cascade rebuild logic.

## Test plan

- [x] `pre-commit run --files docs/build/consolidating-automated-dependency-updates/index.md` passes clean (markdownlint, readability, forbidden-tech, frontmatter checks, mkdocs build)
- [x] `mkdocs build --strict` completes with no errors