### PR TITLE
security: pin mkdocs plugins against unverified properdocs dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 mkdocs-material
 pillow
 cairosvg
-mkdocs-rss-plugin
-mkdocs-redirects
+# pinned below 1.18.0: 1.18.0+ added an unverified "properdocs" runtime dependency (supply-chain concern)
+mkdocs-rss-plugin<1.18.0
+# pinned below 1.2.3: 1.2.3+ added an unverified "properdocs" runtime dependency (supply-chain concern)
+mkdocs-redirects<1.2.3


### PR DESCRIPTION
## What

Pins `mkdocs-rss-plugin` to `<1.18.0` and `mkdocs-redirects` to `<1.2.3` in `requirements.txt`.

## Why

Both plugins recently added a hard runtime dependency on a package called `properdocs`:

- `properdocs` first published to PyPI 2026-03-16, starting at version `1.6.5` (no earlier history).
- Its PyPI author field claims `Tom Christie <tom@tomchristie.com>` — creator of Django REST Framework, Starlette, httpx, uvicorn — with no known connection to MkDocs or MkDocs Material. PyPI does not verify this field.
- `mkdocs-redirects` added it as a required dependency in `1.2.3` (2026-03-28, 12 days after `properdocs` first existed).
- `mkdocs-rss-plugin` added it as a required dependency in `1.18.0` (2026-04-09).
- Importing either plugin (which happens on every `mkdocs build`/`mkdocs serve`) now prints an unsolicited message urging migration away from MkDocs to `properdocs`.

This matches the shape of a dependency-confusion / supply-chain attack: a brand-new package, spoofed authorship, forced in via unrelated third-party plugins shortly after its own creation, with promotional messaging fired on import. `mkdocs-material` itself is unaffected — verified clean, no `properdocs` in its dependency tree.

Verified: installing the pinned versions in a clean virtualenv resolves `mkdocs-rss-plugin==1.17.9` and `mkdocs-redirects==1.2.2` with no `properdocs` present anywhere in the dependency tree.

## Follow-up (not done here)

- Consider reporting `properdocs`, and the compromised/malicious releases of `mkdocs-redirects`/`mkdocs-rss-plugin`, to PyPI security.
- Revisit these pins once the situation is independently confirmed one way or the other.