### PR TITLE
docs: add code examples and cross-link CI/CD compliance audits with audit-compliance section

### DIFF
--- a/docs/enforce/audit-compliance/audit-evidence.md
+++ b/docs/enforce/audit-compliance/audit-evidence.md
@@ -98,6 +98,7 @@ The [Implementation guide](implementation.md) provides:
 - Blog: [Harden Your SDLC Before the Audit Comes](../../blog/posts/2025-12-12-harden-sdlc-before-audit.md) - Initial patterns and audit context
 - [SLSA Provenance Implementation](../slsa-provenance/slsa-provenance.md) - Build attestations for audit trail
 - [SBOM Generation](../../secure/sbom/sbom-generation.md) - Dependency evidence
+- [CI/CD Compliance Audits for Component Integrity](../ci-cd-compliance-audits-for-component-integrity/index.md) - A more specific case: verifying a single artifact's identity, signature, and provenance at release time, rather than collecting evidence across the whole SDLC
 
 **Branch Protection Evidence**:
 

--- a/docs/enforce/ci-cd-compliance-audits-for-component-integrity/index.md
+++ b/docs/enforce/ci-cd-compliance-audits-for-component-integrity/index.md
@@ -1,38 +1,99 @@
 ---
 title: CI/CD Compliance Audits for Component Integrity
 description: >-
-  Implement automated checks within CI/CD pipelines to ensure continuous adherence
-  to software component identity and release process standards, mitigating supply chain risks.
+  Automate component identity and release process checks in CI/CD to catch
+  supply chain violations before deployment.
 ---
 
-Automating compliance audits within the Continuous Integration/Continuous Delivery (CI/CD) pipeline is crucial for maintaining continuous adherence to component identity and release process standards.
-This practice embeds security and compliance checks directly into the development workflow, providing immediate feedback and preventing non-compliant artifacts
-from reaching production environments.
+Compliance audits belong in the pipeline, not in a spreadsheet reviewed after release. A CI job that verifies signatures, diffs SBOMs, and checks provenance attestations blocks a non-compliant artifact before it ships. A quarterly manual review only tells you it already shipped.
+
+This article covers component-identity and release-process audits: proving a specific artifact is what it claims to be, at the moment it moves through the pipeline.
+
+The broader discipline of collecting and reporting evidence across an entire SDLC (branch protection configs, workflow logs, approval records) is covered in [Audit & Compliance](../audit-compliance/audit-evidence.md).
 
 !!! warning "False Sense of Security from Incomplete Audits"
-    Merely adding a compliance step without comprehensive coverage of all critical component attributes or release stages can lead to a false sense of security, potentially allowing vulnerabilities or non-compliant releases to propagate unnoticed.
+    A compliance step that checks one attribute (say, a signature) but ignores others (SBOM drift, provenance) still lets non-compliant releases through. Partial coverage looks like a control on a dashboard and behaves like no control at all.
 
 ## Defining Component Identity Standards
 
-Component identity standards establish verifiable attributes for all software components, including libraries, modules, and dependencies. These standards typically cover:
+Component identity standards are verifiable attributes checked automatically for every library, module, and dependency:
 
-*   **Source Provenance:** Verifying the origin of all components to ensure they come from approved repositories or trusted sources.
-*   **Version Control:** Enforcing specific versioning schemes and preventing the use of unapproved or end-of-life versions.
-*   **Cryptographic Signatures:** Requiring digital signatures for components to confirm their authenticity and integrity throughout the pipeline.
-*   **License Compliance:** Automatically checking component licenses against organizational policies to avoid legal exposure.
+* **Source Provenance:** the component's origin resolves to an approved repository or trusted source.
+* **Version Control:** the version matches an approved scheme; unapproved or end-of-life versions are rejected.
+* **Cryptographic Signatures:** the artifact carries a valid signature confirming authenticity and integrity.
+* **License Compliance:** the declared license matches organizational policy.
 
-### Establishing Release Process Standards
+### Verifying Cryptographic Signatures with Cosign
 
-Release process standards dictate the sequence of operations, approvals, and checks that must occur before a software release can be deployed. Key aspects include:
+A signature check in CI rejects any image that wasn't signed by the expected identity, before it reaches a deployment step:
 
-*   **Approval Gates:** Integrating mandatory human or automated approvals at critical stages, such as after security scans or before deployment to production.
-*   **Environment Segregation:** Ensuring strict separation between development, testing, staging, and production environments.
-*   **Rollback Procedures:** Defining and validating clear rollback strategies for every release.
-*   **Audit Trails:** Capturing immutable logs of all activities, changes, and approvals related to a release.
+```bash
+# Verify container image signature against a keyless (OIDC) identity
+cosign verify \
+  --certificate-identity="https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  registry.example.com/org/app:1.4.2
+```
+
+```yaml
+# .github/workflows/release.yml
+- name: Verify image signature
+  run: |
+    cosign verify \
+      --certificate-identity-regexp="^https://github.com/${{ github.repository }}/" \
+      --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+      "${IMAGE_REF}"
+```
+
+A non-zero exit from `cosign verify` fails the job. No manual sign-off step to forget, no exception to grant.
+
+### Catching Dependency Drift with an SBOM Diff
+
+Signature checks confirm the artifact is authentic; they don't confirm what's inside it changed. Diff the current SBOM against the last approved one to catch dependency additions that skipped review:
+
+```bash
+# Generate SBOM for the current build and diff against the last release
+syft packages dir:. -o cyclonedx-json > sbom-current.json
+
+sbom-diff --old sbom-approved.json --new sbom-current.json \
+  --fail-on-added --fail-on-license-change > sbom-diff-report.json
+
+if [ "$(jq '.violations | length' sbom-diff-report.json)" -gt 0 ]; then
+  echo "SBOM drift detected: new or reclassified components require review"
+  exit 1
+fi
+```
+
+Fail the build on unreviewed additions or license changes, and require a human approval to update `sbom-approved.json` for the next baseline.
+
+## Establishing Release Process Standards
+
+Release process standards define the sequence of operations, approvals, and checks required before deployment:
+
+* **Approval Gates:** mandatory human or automated approvals at critical stages, such as after security scans or before production.
+* **Environment Segregation:** strict separation between development, testing, staging, and production.
+* **Rollback Procedures:** defined and validated rollback strategies for every release.
+* **Audit Trails:** immutable logs of every activity, change, and approval tied to a release.
+
+### Verifying Build Provenance Before Deployment
+
+A signed image and a clean SBOM diff still don't prove the artifact came from the expected build pipeline. Verify the SLSA provenance attestation as a gate before deployment:
+
+```yaml
+# .github/workflows/deploy.yml
+- name: Verify provenance attestation
+  run: |
+    cosign verify-attestation \
+      --type slsaprovenance \
+      --certificate-identity-regexp="^https://github.com/${{ github.repository }}/" \
+      --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+      "${IMAGE_REF}" \
+      | jq -e '.payload | @base64d | fromjson | .predicate.builder.id | test("github.com/org/repo")'
+```
+
+If the builder identity or source repository doesn't match, the `jq` assertion fails and the deploy job stops. This closes the gap that signature verification alone leaves open: a signed artifact built from the wrong source, or by the wrong workflow, still fails the gate.
 
 ### Integrating Automated Audits into CI/CD
-
-To effectively implement compliance audits, integrate specialized tooling at various stages of the CI/CD pipeline.
 
 | Pipeline Stage          | Audit Focus                          | Example Tools/Practices                                                 |
 | :---------------------- | :----------------------------------- | :---------------------------------------------------------------------- |
@@ -43,5 +104,14 @@ To effectively implement compliance audits, integrate specialized tooling at var
 
 ### Continuous Monitoring and Reporting
 
-Automated audits are not a one-time setup but require continuous monitoring and robust reporting. Implement dashboards that display compliance status in real-time, generate alerts for non-compliance, and provide detailed audit logs for forensic analysis. Regular review of audit findings allows for iterative
-improvement of both compliance policies and the automated checks themselves.
+A one-time audit setup goes stale. Feed the results of signature checks, SBOM diffs, and provenance verification into a dashboard that shows compliance status in real time and alerts on failures.
+
+Keep a searchable log for forensic review. Revisit findings on a schedule and tighten both the policies and the checks that enforce them.
+
+## Related Reading
+
+Component-identity and release-integrity checks are one piece of a larger audit program. For evidence collection, retention, and reporting across the full SDLC:
+
+* [Audit Evidence Collection](../audit-compliance/audit-evidence.md): what to collect, how to store it, how to retrieve it for auditors
+* [Evidence Types for Audit Compliance](../audit-compliance/evidence-types.md): the six evidence categories, including SBOM archives and deployment attestations
+* [Compliance Reporting](../audit-compliance/compliance-reporting.md): audit trail reconstruction and tamper-proof storage


### PR DESCRIPTION
## Summary

Editorial-audit fix for `docs/enforce/ci-cd-compliance-audits-for-component-integrity/index.md`:

- Added three concrete CI/CD examples (bash/YAML): cosign signature verification, an SBOM-diff check for dependency drift, and a SLSA provenance-attestation verification gate. This section had zero code blocks despite sitting in `docs/enforce/`, the site's most code-forward section.
- Rewrote generic filler phrasing ("embeds security and compliance checks directly into the development workflow, providing immediate feedback...") into direct, concrete sentences.
- Trimmed the frontmatter `description` from 173 chars to well under the 160-char target.
- Added cross-links in both directions between this article and `docs/enforce/audit-compliance/` (audit-evidence, evidence-types, compliance-reporting), which covers materially overlapping ground but was previously unconnected to this page. This article is now framed as covering component-identity/release-specific audits, a specific case distinct from the more general audit-compliance section.

## Open editorial decision

`docs/enforce/audit-compliance/` and this article still cover overlapping ground. Cross-links have been added in both directions per this fix's scope, but whether these should eventually be merged into one section is a deeper structural decision left for the repo owner — not addressed here.

## Test plan

- [x] `pre-commit run --files <changed files>` passes clean (markdownlint, readability, forbidden-tech, description/title frontmatter checks, mkdocs build)
- [x] `mkdocs build --strict` succeeds with no errors