### PR TITLE
docs: add code examples and conform data contracts article to pattern format

### DIFF
--- a/docs/patterns/authoritative-architectural-documentation-and-data-contracts/index.md
+++ b/docs/patterns/authoritative-architectural-documentation-and-data-contracts/index.md
@@ -1,52 +1,147 @@
 ---
 title: Authoritative Architectural Documentation and Data Contracts
 description: >-
-  Guide to establishing and maintaining architectural documentation as the definitive source for system data flows, differentiating between enforced data contracts and flexible components.
+  Make architecture docs the enforced source of truth for data flows, backed by schema validation in CI that rejects any payload that violates the data contract.
 ---
-Establishing and maintaining rigorous architectural documentation is crucial for systems that require clarity on data flows, especially when differentiating between strictly enforced data contracts and flexibly evolving components.
-This practice ensures that development teams have a single, reliable source of truth, minimizing discrepancies and promoting system stability.
 
-!!! warning "Documentation Drift is a Critical Risk"
-    Failing to keep documentation synchronized with deployed systems can lead to misinformed decisions, integration failures, and significant debugging overhead. Treat architecture documentation as a living artifact, subject to the same rigor as code.
+# Authoritative Architectural Documentation and Data Contracts
 
-## Establishing Documentation as the Authoritative Source
+!!! warning "Documentation Drift Is a Critical Risk"
+    Docs that drift from the deployed system cause bad calls, broken integrations, and debugging sessions that start from a false map. Treat architecture documentation as a living artifact, enforced with the same rigor as code.
 
-To ensure architectural documentation serves as the primary reference for system data flows, implement the following practices:
+## Intent
 
-1.  **Version Control Integration**: Store all architectural documentation in a version control system (e.g., Git) alongside the codebase. This allows for change tracking, rollback capabilities, and integration with CI/CD pipelines.
-2.  **Regular Review and Validation**: Implement a process for regular review and validation of documentation against the actual deployed system. This can involve automated checks (where possible) or scheduled manual audits.
-3.  **Clear Ownership and Update Cadence**: Assign clear ownership for different sections of the documentation. Define a cadence for updates, especially after significant architectural changes or deployment cycles.
-4.  **Accessibility and Discoverability**: Ensure documentation is easily accessible and discoverable by all relevant stakeholders, including developers, operations, and product teams. Use a centralized documentation platform.
-5.  **Focus on Data Flow Diagrams**: Emphasize clear and concise data flow diagrams (DFDs) that illustrate the movement of data between components and systems. These should be accompanied by detailed descriptions of data formats and protocols.
+**Make architectural documentation the enforced source of truth for data flows, and make the boundary between strict data contracts and flexible components explicit and checkable.**
 
-### Differentiating Data Contracts and Flexible Components
+Most systems mix two kinds of data structure: contracts that external consumers depend on, and internal shapes a team can change on its own schedule. When documentation does not draw that line clearly, both sides lose.
 
-A critical aspect of rigorous documentation is clearly defining which parts of the system are governed by strict data contracts and which are designed for flexible evolution.
+Consumers build against internals that shift under them. Teams stop iterating because they are not sure what is safe to touch.
 
-**Data Contracts** define the immutable agreements between system components regarding the structure, format, and semantics of data. These are typically enforced at system boundaries, ensuring compatibility and preventing downstream failures.
+## Motivation
 
-**Flexible Components** are parts of the system whose internal implementation and data structures can evolve more rapidly, provided they continue to adhere to any defined external data contracts.
+Use this pattern when:
 
-| Characteristic         | Data Contracts                                        | Flexible Components                                  |
-| :--------------------- | :---------------------------------------------------- | :--------------------------------------------------- |
-| **Purpose**            | Guarantee compatibility, prevent breaking changes     | Enable rapid iteration, internal optimization        |
-| **Enforcement**        | Strict, often automated via schema validation         | Internal best practices, team conventions            |
-| **Impact of Change**   | High, requires coordinated updates across consumers   | Low, primarily affects internal implementation       |
-| **Examples**           | API schemas (OpenAPI), message bus schemas (Avro/JSON Schema), public data models | Internal data structures, temporary processing queues, UI state models |
-| **Documentation Focus**| Formal definitions, versioning, change logs           | High-level overview, behavioral descriptions         |
+- **Multiple teams or services consume the same data.** A schema change from one team breaks another team's pipeline without warning.
+- **Docs and code have already drifted once.** If it happened once, it will happen again without enforcement.
+- **Onboarding requires guessing which fields are safe to change.** New engineers should not have to read consumer code to find out.
+- **Data crosses a trust boundary.** Ingestion pipelines, message buses, and public APIs all need a documented, validated shape at the edge.
 
-### Documenting Enforced Data Contracts
+Skip the heavyweight version of this pattern for single-service internal state that never crosses a boundary. Enforce it wherever data moves between components owned by different teams.
 
-For areas of the system with enforced data contracts, documentation must explicitly state the contract and its enforcement mechanisms.
+## Structure
 
-For instance, consider a "Structured Data Domain" within a data ingestion pipeline. Its documentation should clearly state:
+A contract has three parts: the schema, the enforcement gate, and the documentation that points at both.
 
-*   **Contracted Nature**: This domain adheres to a strict data contract.
-*   **Enforcement Gates**: Data entering this domain is validated against a defined schema via "admission and upload gates" (e.g., schema registries, API gateways with validation rules).
-*   **Implications**: Consumers of data from this domain can rely on the documented shape of the data being guaranteed, not merely by convention.
+| Characteristic | Data Contracts | Flexible Components |
+| --------------- | -------------- | -------------------- |
+| Purpose | Guarantee compatibility, block breaking changes | Enable fast internal iteration |
+| Enforcement | Automated schema validation at the boundary | Team convention, code review |
+| Blast radius of a change | High, requires coordinated update across consumers | Low, contained to one component |
+| Examples | API schemas, message bus payloads, public data models | Internal structs, scratch queues, UI state |
+| Doc focus | Formal schema, version history, changelog | High-level behavior, not field-by-field detail |
 
-### Documenting Flexibly Evolving Components
+Documentation for a contracted domain states three things:
 
-Conversely, for components that are deliberately unconstrained by formal external contracts, documentation should reflect this flexibility.
-Clearly state that these components may evolve rapidly and that their internal data structures are subject to change without broader system coordination, as long as they respect any outward-facing contracts.
-This manages expectations for consumers and allows development teams the agility needed for innovation.
+1. **Contracted nature**: this domain is governed by a schema, not by convention.
+2. **Enforcement gate**: where validation runs and what it blocks (schema registry, API gateway, CI check).
+3. **Consumer guarantee**: what shape a consumer can rely on, and what constitutes a breaking change.
+
+Documentation for a flexible component states that it is unconstrained internally, as long as it still satisfies any contract it exposes outward.
+
+## Implementation
+
+### Define the contract as a schema, not a paragraph
+
+A schema is testable. A paragraph is not.
+
+```json title="schemas/order-created.schema.json"
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.internal/schemas/order-created.schema.json",
+  "title": "OrderCreated",
+  "type": "object",
+  "required": ["order_id", "customer_id", "amount_cents", "currency", "created_at"],
+  "properties": {
+    "order_id": { "type": "string", "format": "uuid" },
+    "customer_id": { "type": "string", "format": "uuid" },
+    "amount_cents": { "type": "integer", "minimum": 0 },
+    "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}
+```
+
+`additionalProperties: false` is the enforcement teeth. It turns an undocumented field into a rejected payload instead of a silent addition nobody reviewed.
+
+### Validate every payload against the schema, in CI
+
+The schema is worthless if nothing checks payloads against it before merge.
+
+```bash title="scripts/validate-contract.sh"
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCHEMA="schemas/order-created.schema.json"
+SAMPLES_DIR="samples/order-created"
+
+for sample in "${SAMPLES_DIR}"/*.json; do
+  echo "Validating ${sample} against ${SCHEMA}"
+  check-jsonschema --schemafile "${SCHEMA}" "${sample}"
+done
+```
+
+Wire the script into the pipeline so a schema violation fails the build, not just a code review comment:
+
+```yaml title=".github/workflows/validate-data-contracts.yml"
+name: Validate Data Contracts
+
+on:
+  pull_request:
+    paths:
+      - "schemas/**"
+      - "samples/**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install validator
+        run: pip install check-jsonschema
+      - name: Validate contract samples
+        run: bash scripts/validate-contract.sh
+```
+
+Point the documentation for this domain directly at the schema file and this workflow. A reader should be able to jump from the doc to the exact gate that enforces it, not take the doc's word for it.
+
+### Keep the doc close to the gate
+
+- **Version the schema in the same repo as the docs**, so a schema change and its doc update land in the same pull request.
+- **Link the doc section to the schema file path and the CI job name**, not to a description of them.
+- **Review schema changes like API changes.** A required field added to `required` is a breaking change for every consumer.
+
+## Consequences
+
+### Benefits
+
+| Benefit | Impact |
+| ------- | ------ |
+| Enforced compatibility | Consumers build against a guarantee, not a guess |
+| Faster onboarding | New engineers read one schema instead of tracing consumer code |
+| Caught drift | A payload that violates the contract fails CI before it reaches production |
+| Clear iteration boundary | Teams know exactly which fields they can change freely |
+
+### Trade-offs
+
+| Trade-off | Mitigation |
+| --------- | ---------- |
+| Schema maintenance overhead | Only apply to boundaries with real external consumers |
+| Slower changes to contracted fields | That friction is the point: coordinate before breaking consumers |
+| Docs can still drift from the schema file itself | Link, don't duplicate. The doc should reference the schema, not restate it |
+
+## Related Patterns
+
+- **[Secure-by-Design Pattern Library](../security/secure-by-design/index.md)**: Enforcing properties at admission time rather than trusting convention
+- **[Fail Fast](../error-handling/fail-fast/index.md)**: Rejecting bad input before it enters the pipeline
+- **[Three-Stage Design](../index.md#pattern_categories)**: Validation as a discrete stage before processing


### PR DESCRIPTION
## Summary

Editorial fixes to `docs/patterns/authoritative-architectural-documentation-and-data-contracts/index.md`:

- Restructured headings to follow the site's documented Pattern Documentation Format (Intent / Motivation / Structure / Implementation / Consequences / Related Patterns), matching sibling pattern pages. Stays under `docs/patterns/`, no nav relocation.
- Added a concrete code example: a JSON Schema data contract, a bash validation script using `check-jsonschema`, and a GitHub Actions workflow that fails the build on a schema violation.
- Rewrote corporate-whitepaper phrasing ("is crucial for," "promotes system stability," "ensures... minimizing discrepancies") into direct, tactical sentences.
- Trimmed the frontmatter `description` from 186 chars to 159 chars, under the 160-char target.
- Kept the content vendor-neutral per README.md's Content Policies.
- No em/en-dashes introduced (house style / `adaptive-enforcement-lab/readability` hook).

## Test plan

- [x] `pre-commit run --files docs/patterns/authoritative-architectural-documentation-and-data-contracts/index.md` passes clean (markdownlint, readability, forbidden-tech, description/title checks, mkdocs build)
- [x] `mkdocs build --strict` succeeds with no warnings or errors