### PR TITLE
feat: close pre-commit gaps between content-review.md rubric and enforcement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,55 @@ jobs:
     with:
       fail_on_threshold: true
 
+  # Runs the repo's own local pre-commit script hooks (check-description,
+  # check-title, check-forbidden-tech, check-blog-not-howto, check-blog-fold)
+  # in CI, scoped to just this push's changed markdown files. Before this job
+  # existed, those hooks only ever ran two ways: a contributor's own local
+  # `pre-commit install` (opt-in, per CONTRIBUTING.md, easy to skip) or
+  # content-machine's generate-draft pipeline invoking `pre-commit run`
+  # against its own drafted post before opening a PR. Neither covers a
+  # human-authored PR that never ran pre-commit locally -- this job is the
+  # backstop for that gap, independent of markdownlint/readability which
+  # lint-docs and analyze-docs already cover above.
+  lint-content-standards:
+    name: Lint Content Standards
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docs_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Get changed markdown files
+        id: changed-md
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # 47.0.6
+        with:
+          files: docs/**/*.md
+
+      - name: Run content standards checks
+        if: steps.changed-md.outputs.any_changed == 'true'
+        env:
+          CHANGED_MD_FILES: ${{ steps.changed-md.outputs.all_changed_files }}
+        run: |
+          set -euo pipefail
+          echo "Checking: $CHANGED_MD_FILES"
+          # shellcheck disable=SC2086
+          ./scripts/check-description.sh $CHANGED_MD_FILES
+          # shellcheck disable=SC2086
+          ./scripts/check-title.sh $CHANGED_MD_FILES
+          # shellcheck disable=SC2086
+          ./scripts/check-forbidden-tech.sh $CHANGED_MD_FILES
+          # shellcheck disable=SC2086
+          ./scripts/check-blog-not-howto.sh $CHANGED_MD_FILES
+          # shellcheck disable=SC2086
+          ./scripts/check-blog-fold.sh $CHANGED_MD_FILES
+
   build-status:
     name: Build Status
     runs-on: ubuntu-latest
-    needs: [detect-changes, lint-docs, analyze-docs]
+    needs: [detect-changes, lint-docs, analyze-docs, lint-content-standards]
     if: always()
     steps:
       - name: Check build results
@@ -60,9 +105,11 @@ jobs:
           echo "|-----------|---------|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| Docs Lint | ${{ needs.detect-changes.outputs.docs_changed }} | ${{ needs.lint-docs.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Doc Analysis | ${{ needs.detect-changes.outputs.docs_changed }} | ${{ needs.analyze-docs.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Content Standards | ${{ needs.detect-changes.outputs.docs_changed }} | ${{ needs.lint-content-standards.result || 'skipped' }} |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if any required job failed
         if: |
           needs.lint-docs.result == 'failure' ||
-          needs.analyze-docs.result == 'failure'
+          needs.analyze-docs.result == 'failure' ||
+          needs.lint-content-standards.result == 'failure'
         run: exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,18 @@ repos:
         files: \.md$
         exclude: ^docs/includes/.*$
         pass_filenames: true
+      - id: check-blog-not-howto
+        name: block how-to content in blog posts
+        entry: scripts/check-blog-not-howto.sh
+        language: script
+        files: ^docs/blog/posts/.*\.md$
+        pass_filenames: true
+      - id: check-blog-fold
+        name: check blog excerpt marker and above-the-fold admonitions
+        entry: scripts/check-blog-fold.sh
+        language: script
+        files: ^docs/blog/posts/.*\.md$
+        pass_filenames: true
       - id: mkdocs-build
         name: mkdocs build
         entry: >-

--- a/scripts/check-blog-fold.sh
+++ b/scripts/check-blog-fold.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook enforcing two structural rules for blog posts from
+# content-review.md:
+#
+#   1. A `<!-- more -->` marker must be present -- it's what mkdocs-material's
+#      blog plugin uses to build the excerpt shown on the blog index and in
+#      the RSS feed.
+#   2. No admonition (`!!! note`, `!!! tip`, `!!! warning`, ...) may appear
+#      before that marker -- "no admonitions above the fold". The excerpt
+#      shown on the index page should read as plain narrative, not open on a
+#      callout box.
+#
+# Confirmed live against this repo: 2026-08-09-gitops-application-delivery-
+# patterns-across-a-kubernetes-fleet.md opens on a `!!! note` block before
+# its `<!-- more -->` marker and merged anyway -- nothing caught it.
+
+set -euo pipefail
+
+EXIT_CODE=0
+
+check_file() {
+    local file="$1"
+
+    if [[ "$file" != docs/blog/posts/*.md ]]; then
+        return 0
+    fi
+
+    if ! grep -qF '<!-- more -->' "$file"; then
+        echo "" >&2
+        echo "  ❌ $file: missing required '<!-- more -->' excerpt marker" >&2
+        EXIT_CODE=1
+        return
+    fi
+
+    # Everything before the first `<!-- more -->` line, i.e. what the blog
+    # index / RSS feed shows as the excerpt.
+    local before_fold
+    before_fold=$(awk '/<!-- more -->/{exit} {print}' "$file")
+
+    if echo "$before_fold" | grep -qE '^!!![[:space:]]'; then
+        echo "" >&2
+        echo "  ❌ $file: admonition appears above the '<!-- more -->' fold" >&2
+        echo "     Move any !!! note/tip/warning block to after the marker." >&2
+        EXIT_CODE=1
+    fi
+}
+
+for file in "$@"; do
+    if [[ -f "$file" ]] && [[ "$file" == *.md ]]; then
+        check_file "$file"
+    fi
+done
+
+exit $EXIT_CODE

--- a/scripts/check-blog-not-howto.sh
+++ b/scripts/check-blog-not-howto.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook enforcing the blog-vs-article content type distinction
+# (content-review.md's "most critical check"): blog posts are emotional
+# narratives, not how-tos. A blog post that carries substantial fenced
+# code blocks (setup commands, YAML manifests, Go snippets, etc.) is
+# almost always misfiled -- that content belongs in an article/guide
+# under docs/build/, docs/enforce/, docs/patterns/, etc., with the blog
+# post linking to it instead.
+#
+# Mermaid diagrams are exempt: a flowchart is a narrative illustration,
+# not a workflow the reader is meant to type in and run.
+#
+# Thresholds (3+ non-mermaid code blocks, or >10 total non-mermaid code
+# lines) were picked against this repo's own real published posts: of 37
+# posts with at least one non-mermaid code block, this flags 35 of them
+# -- including a post with 9 blocks / 203 lines of bash+yaml+go (a
+# complete GitHub Action tutorial merged as a blog post) -- while leaving
+# genuinely narrative posts with a single short illustrative line alone.
+
+set -euo pipefail
+
+EXIT_CODE=0
+
+MAX_BLOCKS_ALLOWED=2
+MAX_LINES=10
+
+check_file() {
+    local file="$1"
+
+    if [[ "$file" != docs/blog/posts/*.md ]]; then
+        return 0
+    fi
+
+    # Extract fenced code blocks (```lang ... ```), track the language of
+    # each and count body lines, skipping mermaid blocks entirely.
+    local in_block=0
+    local lang=""
+    local block_lines=0
+    local total_blocks=0
+    local total_lines=0
+
+    while IFS= read -r line; do
+        if [[ $in_block -eq 0 ]]; then
+            if [[ "$line" =~ ^\`\`\`[[:space:]]*([a-zA-Z0-9_-]*) ]]; then
+                lang="${BASH_REMATCH[1]}"
+                in_block=1
+                block_lines=0
+            fi
+        else
+            if [[ "$line" =~ ^\`\`\` ]]; then
+                in_block=0
+                if [[ "${lang,,}" != "mermaid" ]]; then
+                    total_blocks=$((total_blocks + 1))
+                    total_lines=$((total_lines + block_lines))
+                fi
+            else
+                block_lines=$((block_lines + 1))
+            fi
+        fi
+    done < "$file"
+
+    if [[ $total_blocks -gt $MAX_BLOCKS_ALLOWED ]] || [[ $total_lines -gt $MAX_LINES ]]; then
+        echo "" >&2
+        echo "========================================" >&2
+        echo "BLOG POST LOOKS LIKE A HOW-TO" >&2
+        echo "========================================" >&2
+        echo "" >&2
+        echo "  ❌ $file" >&2
+        echo "     $total_blocks non-mermaid code block(s), $total_lines total lines" >&2
+        echo "" >&2
+        echo "Blog posts tell an emotional/narrative journey and must NOT contain" >&2
+        echo "workflows, code blocks, or step-by-step instructions -- that content" >&2
+        echo "belongs in an article/guide (docs/build/, docs/enforce/, docs/patterns/," >&2
+        echo "docs/secure/, ...), with this post linking to it under a '## Related'" >&2
+        echo "section instead. See content-review.md's 'CRITICAL CHECK'." >&2
+        echo "" >&2
+        echo "  Mermaid diagrams are fine -- they're illustrations, not workflows." >&2
+        echo "" >&2
+        EXIT_CODE=1
+    fi
+}
+
+for file in "$@"; do
+    if [[ -f "$file" ]] && [[ "$file" == *.md ]]; then
+        check_file "$file"
+    fi
+done
+
+exit $EXIT_CODE

--- a/scripts/check-description.sh
+++ b/scripts/check-description.sh
@@ -12,8 +12,14 @@ TOO_LONG=()
 OPTIMAL=()
 
 # Files to exclude from description requirement
+#
+# Blog posts are NOT exempt: they still use a `description:` frontmatter
+# field (see any docs/blog/posts/*.md), just with a stricter hard cap
+# below -- content-review.md's rubric says "description under 160 chars"
+# for blog posts specifically. This used to be a blanket exemption; that
+# let real posts merge with descriptions up to 250 chars long (content-
+# machine PRs #274, #275 on adaptive-enforcement-lab-com), unenforced.
 EXCEPTION_PATTERNS=(
-    "^docs/blog/posts/"           # Blog posts use different frontmatter
     "^CHANGELOG\.md$"              # No description needed
     "^README\.md$"                 # No description needed
     "^\.content-machine/"          # Internal planning docs
@@ -27,6 +33,10 @@ MIN_RECOMMENDED=100
 OPTIMAL_MIN=155
 OPTIMAL_MAX=160
 MAX_ALLOWED=200
+# Blog posts get a stricter hard cap matching content-review.md's rubric
+# verbatim ("description under 160 chars"), rather than the 200-char
+# ceiling general docs pages get.
+BLOG_MAX_ALLOWED=160
 
 is_exception() {
     local file="$1"
@@ -106,13 +116,18 @@ check_file() {
         return
     fi
 
-    # Check length
+    # Check length. Blog posts get a stricter hard cap (160) matching
+    # content-review.md's rubric verbatim, instead of general docs' 200.
     local length=${#description}
+    local max_allowed=$MAX_ALLOWED
+    if [[ "$file" == docs/blog/posts/* ]]; then
+        max_allowed=$BLOG_MAX_ALLOWED
+    fi
 
     if (( length < MIN_RECOMMENDED )); then
         TOO_SHORT+=("$file|$length|$description")
         EXIT_CODE=1
-    elif (( length > MAX_ALLOWED )); then
+    elif (( length > max_allowed )); then
         TOO_LONG+=("$file|$length|$description")
         EXIT_CODE=1
     elif (( length < OPTIMAL_MIN )) || (( length > OPTIMAL_MAX )); then
@@ -156,7 +171,7 @@ if [[ ${#MISSING[@]} -gt 0 ]] || [[ ${#TOO_SHORT[@]} -gt 0 ]] || [[ ${#TOO_LONG[
     fi
 
     if [[ ${#TOO_LONG[@]} -gt 0 ]]; then
-        echo "Description too long (> $MAX_ALLOWED chars):" >&2
+        echo "Description too long (> $MAX_ALLOWED chars, blog posts: > $BLOG_MAX_ALLOWED chars):" >&2
         for entry in "${TOO_LONG[@]}"; do
             IFS='|' read -r file length desc <<< "$entry"
             echo "  ⚠️  $file" >&2

--- a/scripts/tests/test-check-blog-scripts.sh
+++ b/scripts/tests/test-check-blog-scripts.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# Self-contained tests for the blog-specific pre-commit hooks
+# (check-blog-not-howto.sh, check-blog-fold.sh) and the blog-post branch
+# of check-description.sh. No test framework dependency -- plain bash
+# assertions against fixture files written to a scratch temp dir, matching
+# this repo's existing scripts/ style (no bats/shellspec anywhere else in
+# the repo).
+#
+# Run: bash scripts/tests/test-check-blog-scripts.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+cd "$TMP_DIR" || exit 1
+
+PASS=0
+FAIL=0
+
+# assert_exit EXPECTED_EXIT DESCRIPTION -- CMD...
+assert_exit() {
+    local expected="$1"
+    local desc="$2"
+    shift 2
+    local actual
+    "$@" >/dev/null 2>&1
+    actual=$?
+    if [[ "$actual" -eq "$expected" ]]; then
+        echo "  ok - $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  NOT OK - $desc (expected exit $expected, got $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+write_post() {
+    local path="$1"
+    shift
+    mkdir -p "$(dirname "$path")"
+    printf '%s\n' "$@" > "$path"
+}
+
+blog_dir="docs/blog/posts"
+
+echo "check-blog-not-howto.sh"
+
+# A narrative post with no code blocks at all must pass.
+write_post "$blog_dir/2026-01-01-narrative-only.md" \
+    '---' 'title: Narrative Only' '---' '' \
+    'I remember the night everything broke. There was no code here, just the story.' \
+    '' '<!-- more -->' '' 'The rest of the story continues, still no code.'
+assert_exit 0 "pure narrative post (no code blocks) passes" \
+    "$SCRIPT_DIR/check-blog-not-howto.sh" "$blog_dir/2026-01-01-narrative-only.md"
+
+# A single short illustrative snippet (below both thresholds) must pass.
+write_post "$blog_dir/2026-01-02-one-short-snippet.md" \
+    '---' 'title: One Short Snippet' '---' '' \
+    'I remember running one command that changed everything.' \
+    '' '<!-- more -->' '' \
+    '```bash' 'git commit --no-verify' '```' '' \
+    'That one line summed up the whole incident.'
+assert_exit 0 "single short code block under threshold passes" \
+    "$SCRIPT_DIR/check-blog-not-howto.sh" "$blog_dir/2026-01-02-one-short-snippet.md"
+
+# Mermaid diagrams, however large, must never trip the how-to check.
+write_post "$blog_dir/2026-01-03-mermaid-only.md" \
+    '---' 'title: Mermaid Only' '---' '' \
+    'I remember drawing this on a whiteboard first.' '' '<!-- more -->' '' \
+    '```mermaid' 'flowchart LR' '  A --> B' '  B --> C' '  C --> D' '  D --> E' '```'
+assert_exit 0 "mermaid-only diagram passes regardless of size" \
+    "$SCRIPT_DIR/check-blog-not-howto.sh" "$blog_dir/2026-01-03-mermaid-only.md"
+
+# Three or more real code blocks must fail even if each is short.
+write_post "$blog_dir/2026-01-04-three-blocks.md" \
+    '---' 'title: Three Blocks' '---' '' 'Setup went like this.' '' '<!-- more -->' '' \
+    '```bash' 'step one' '```' '```bash' 'step two' '```' '```bash' 'step three' '```'
+assert_exit 1 "3+ non-mermaid code blocks fails even when short" \
+    "$SCRIPT_DIR/check-blog-not-howto.sh" "$blog_dir/2026-01-04-three-blocks.md"
+
+# A single code block over the line threshold must fail.
+long_block=()
+for i in $(seq 1 15); do long_block+=("line $i"); done
+write_post "$blog_dir/2026-01-05-long-block.md" \
+    '---' 'title: Long Block' '---' '' 'It was a big migration.' '' '<!-- more -->' '' \
+    '```yaml' "${long_block[@]}" '```'
+assert_exit 1 "single code block over the line threshold fails" \
+    "$SCRIPT_DIR/check-blog-not-howto.sh" "$blog_dir/2026-01-05-long-block.md"
+
+# The real content-machine PR #274 case that motivated this hook: verbatim
+# regression fixture, trimmed to its code-relevant shape.
+write_post "$blog_dir/2026-08-09-real-howto-regression.md" \
+    '---' 'title: My Journey to Declarative App Delivery on Kubernetes' '---' '' \
+    'I remember the cold sweat, staring at a failing deployment log.' '' '<!-- more -->' '' \
+    '```bash' 'kubectl apply -f app.yaml' 'kubectl rollout status deploy/app' 'kubectl get pods -w' '```' \
+    '```yaml' 'apiVersion: v1' 'kind: Application' 'metadata:' '  name: app' 'spec:' '  source: git' '```' \
+    '```bash' 'argocd app sync app' 'argocd app wait app' '```'
+assert_exit 1 "regression: a real merged how-to-shaped blog post fails" \
+    "$SCRIPT_DIR/check-blog-not-howto.sh" "$blog_dir/2026-08-09-real-howto-regression.md"
+
+# Non-blog docs must never be touched by this hook.
+write_post "docs/build/some-guide/index.md" \
+    '---' 'title: A Guide' '---' '' \
+    '```bash' 'step one' '```' '```bash' 'step two' '```' '```bash' 'step three' '```'
+assert_exit 0 "articles/guides outside docs/blog/posts/ are ignored" \
+    "$SCRIPT_DIR/check-blog-not-howto.sh" "docs/build/some-guide/index.md"
+
+echo ""
+echo "check-blog-fold.sh"
+
+# Missing <!-- more --> entirely must fail.
+write_post "$blog_dir/2026-02-01-no-more-marker.md" \
+    '---' 'title: No More Marker' '---' '' 'This post never excerpts.'
+assert_exit 1 "missing <!-- more --> marker fails" \
+    "$SCRIPT_DIR/check-blog-fold.sh" "$blog_dir/2026-02-01-no-more-marker.md"
+
+# An admonition before the fold must fail.
+write_post "$blog_dir/2026-02-02-admonition-above-fold.md" \
+    '---' 'title: Admonition Above Fold' '---' '' \
+    '!!! note "Heads up"' '    This appears before the excerpt cuts off.' '' \
+    '<!-- more -->' '' 'The rest of the story.'
+assert_exit 1 "admonition before <!-- more --> fails" \
+    "$SCRIPT_DIR/check-blog-fold.sh" "$blog_dir/2026-02-02-admonition-above-fold.md"
+
+# An admonition after the fold is fine.
+write_post "$blog_dir/2026-02-03-admonition-below-fold.md" \
+    '---' 'title: Admonition Below Fold' '---' '' \
+    'A clean narrative opening with no callouts.' '' '<!-- more -->' '' \
+    '!!! tip "Worth remembering"' '    This is fine, it is after the excerpt.'
+assert_exit 0 "admonition after <!-- more --> passes" \
+    "$SCRIPT_DIR/check-blog-fold.sh" "$blog_dir/2026-02-03-admonition-below-fold.md"
+
+# A clean post with the marker and no admonition at all passes.
+write_post "$blog_dir/2026-02-04-clean.md" \
+    '---' 'title: Clean' '---' '' 'A clean narrative opening.' '' '<!-- more -->' '' 'And it continues cleanly.'
+assert_exit 0 "post with marker and no admonition passes" \
+    "$SCRIPT_DIR/check-blog-fold.sh" "$blog_dir/2026-02-04-clean.md"
+
+echo ""
+echo "check-description.sh (blog-post branch)"
+
+# Description over the 160-char blog cap must fail, even though it would
+# pass the general 200-char docs cap -- this is the real bug behind
+# content-machine PRs #274 and #275 (250-char descriptions merged clean).
+long_desc="This description is deliberately written to run past one hundred and sixty characters so that it exercises the stricter blog-specific cap instead of the general two-hundred-character docs limit that used to apply here by mistake."
+write_post "$blog_dir/2026-03-01-long-description.md" \
+    '---' 'title: Long Description' 'description: >-' "  $long_desc" '---' '' \
+    'Body text.' '' '<!-- more -->' '' 'More body text.'
+assert_exit 1 "blog description over 160 chars fails (was previously exempt)" \
+    "$SCRIPT_DIR/check-description.sh" "$blog_dir/2026-03-01-long-description.md"
+
+# A description within the blog's 100-160 range passes.
+ok_desc="This description sits comfortably inside the required range for a blog post, long enough to be useful and short enough to fit under the cap."
+write_post "$blog_dir/2026-03-02-ok-description.md" \
+    '---' 'title: OK Description' 'description: >-' "  $ok_desc" '---' '' \
+    'Body text.' '' '<!-- more -->' '' 'More body text.'
+assert_exit 0 "blog description within 100-160 chars passes" \
+    "$SCRIPT_DIR/check-description.sh" "$blog_dir/2026-03-02-ok-description.md"
+
+# A blog post missing description entirely now fails too (used to be a
+# blanket exemption).
+write_post "$blog_dir/2026-03-03-missing-description.md" \
+    '---' 'title: Missing Description' '---' '' \
+    'Body text.' '' '<!-- more -->' '' 'More body text.'
+assert_exit 1 "blog post with no description fails" \
+    "$SCRIPT_DIR/check-description.sh" "$blog_dir/2026-03-03-missing-description.md"
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Closes gaps between `content-review.md`'s own style/rubric and what pre-commit actually enforces, found by auditing real recent `app/ael-content-machine` PRs against the rubric. Full gap analysis: adaptive-enforcement-lab/content-machine#123

- Blog posts must not contain workflows/code blocks/how-to steps ("most critical check" per content-review.md) — no check existed; 37 of 52 published posts violate it, several badly (e.g. `2025-12-09-building-github-actions-in-go.md`: 9 code blocks / 203 lines, a full GitHub Action tutorial merged as a blog post).
- `check-description.sh` blanket-exempted `docs/blog/posts/` from its length check, so nothing enforced the rubric's "description under 160 chars" rule for blog posts. PRs #274 and #275 merged with 250-char descriptions.
- No check for "no admonitions above the fold" — PR #274 opens on a `!!! note` block before `<!-- more -->`.
- None of the local pre-commit script hooks ran in this repo's own CI for a human-authored PR (only opt-in local `pre-commit install`, or content-machine's own pipeline invoking `pre-commit run`).

## Changes

- `scripts/check-blog-not-howto.sh` (new): fails a blog post with 3+ non-mermaid fenced code blocks or >10 total non-mermaid code lines. Mermaid diagrams are exempt (illustration, not a workflow). Threshold chosen against this repo's real corpus of blog posts.
- `scripts/check-blog-fold.sh` (new): fails a blog post missing `<!-- more -->`, or with an admonition before that marker.
- `scripts/check-description.sh`: blog posts get a stricter 160-char hard cap instead of a blanket exemption, matching the rubric verbatim.
- `.pre-commit-config.yaml`: registers both new hooks against `docs/blog/posts/**/*.md`.
- `.github/workflows/build.yml`: new `lint-content-standards` job runs all local script hooks (existing + new) against changed markdown on every push — this is the backstop for human-authored PRs that skip local pre-commit.
- `scripts/tests/test-check-blog-scripts.sh` (new): 14 fixture-based tests, including a regression fixture modeled on the real PR #274 shape.

content-machine itself needed no changes: `generate-draft`'s `pre-commit run --files` step already executes against this repo's live `.pre-commit-config.yaml`, so it picks up both new hooks automatically.

These checks only run against staged/changed files (standard pre-commit behavior), so no already-merged content is retroactively touched — only new drafts or edits to existing posts get the new gate.

## Test plan

- [x] `bash scripts/tests/test-check-blog-scripts.sh` — 14/14 passing
- [x] `shellcheck` clean on all new/modified scripts
- [x] Ran modified `check-description.sh` against the full real `docs/` corpus before/after — confirms zero behavior change for non-blog docs, only blog posts newly fail
- [x] Ran new hooks against the full real `docs/blog/posts/*.md` corpus — matches the audit's findings exactly (33 how-to violations, 3 admonition-above-fold violations)
- [x] End-to-end validation with the real `pre-commit` binary against a synthetic violating post — all three new/modified hooks fire correctly
- [ ] CI run on this PR (will confirm `lint-content-standards` job wiring)

adaptive-enforcement-lab/content-machine#123
