### PR TITLE
fix: remove dangling pre-commit hook entries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,18 +34,6 @@ repos:
         files: \.md$
         exclude: ^docs/includes/.*$
         pass_filenames: true
-      - id: check-blog-not-howto
-        name: block how-to content in blog posts
-        entry: scripts/check-blog-not-howto.sh
-        language: script
-        files: ^docs/blog/posts/.*\.md$
-        pass_filenames: true
-      - id: check-blog-fold
-        name: check blog excerpt marker and above-the-fold admonitions
-        entry: scripts/check-blog-fold.sh
-        language: script
-        files: ^docs/blog/posts/.*\.md$
-        pass_filenames: true
       - id: mkdocs-build
         name: mkdocs build
         entry: >-


### PR DESCRIPTION
## What

Removes two pre-commit hook entries (\`check-blog-not-howto\`, \`check-blog-fold\`) from \`.pre-commit-config.yaml\` that reference scripts (\`scripts/check-blog-not-howto.sh\`, \`scripts/check-blog-fold.sh\`) which don't exist anywhere in the repo's git history.

## How this happened

While resolving a merge conflict on PR #280 (git-merging \`main\` into its branch to bring in unrelated nav changes), my working directory picked up these two hook entries from another concurrent process operating in the same directory — they were present on disk but never actually committed anywhere. My conflict-resolution commit staged \`.pre-commit-config.yaml\` and unintentionally carried them into #280's squash-merge onto \`main\`, without the corresponding scripts. Every pre-commit run touching a blog post has been failing since with a missing-entry-point error.

## Fix

Removed both hook entries. If/when the underlying scripts land (they look like genuinely useful checks — blocking how-to content in blog posts and validating the excerpt-fold/admonition placement), they should be added together with the hooks that reference them, in one commit.