### PR TITLE
fix: group flat dependency-management nav leaves

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -428,9 +428,10 @@ nav:
           - Mike Configuration: build/versioned-docs/mike-configuration.md
           - Pipeline Integration: build/versioned-docs/pipeline-integration.md
           - Version Strategies: build/versioned-docs/version-strategies.md
-      - Consolidating Automated Dependency Updates: build/consolidating-automated-dependency-updates/index.md
-      - Managing Incompatible Dependency Updates: build/managing-incompatible-dependency-updates/index.md
-      - Structured Component Version Promotion: build/structured-component-version-promotion/index.md
+      - Dependency Management:
+          - Automated Updates: build/consolidating-automated-dependency-updates/index.md
+          - Incompatible Updates: build/managing-incompatible-dependency-updates/index.md
+          - Version Promotion: build/structured-component-version-promotion/index.md
   - Secure:
       - secure/index.md
       - GitHub Apps:


### PR DESCRIPTION
## Summary

3 unrelated flat top-level `Build` nav leaves (Consolidating Automated
Dependency Updates / Managing Incompatible Dependency Updates / Structured
Component Version Promotion) shared a topic but not a group, with 4-5 word
labels next to genuinely short hand-picked siblings elsewhere in `Build`
(Change Detection, Workflow Triggers). Grouped under a new
`Dependency Management` rubric, labels shortened to 2 words each. Paths
unchanged, no content moved.

## Verification

- `mkdocs build --strict`: clean, no broken links/nav errors.